### PR TITLE
Navbar styling

### DIFF
--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -96,18 +96,23 @@
     }
   }
 
-  .nhsuk-header__menu-toggle {
+  .nhsuk-header__menu-toggle, .nhsuk-header__menu-toggle:hover {
     border: none;
 
-    svg {
-      display: none;
-
-      @include mq($until: tablet) {
-        display: block;
-        text-align: center;
-        margin: 0 auto;
-      }
+    span {
+      padding-top: 28px;
+      display: block;
+      font-weight: normal;
     }
+      background-image: url("data:image/svg+xml,%3Csvg width='24' height='21' viewBox='0 0 24 21' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.857143 3.84437H23.1429C23.6163 3.84437 24 3.46191 24 2.99007V0.854305C24 0.382462 23.6163 0 23.1429 0H0.857143C0.383732 0 0 0.382462 0 0.854305V2.99007C0 3.46191 0.383732 3.84437 0.857143 3.84437ZM0.857143 12.3874H23.1429C23.6163 12.3874 24 12.005 24 11.5331V9.39735C24 8.92551 23.6163 8.54305 23.1429 8.54305H0.857143C0.383732 8.54305 0 8.92551 0 9.39735V11.5331C0 12.005 0.383732 12.3874 0.857143 12.3874ZM0.857143 20.9305H23.1429C23.6163 20.9305 24 20.548 24 20.0762V17.9404C24 17.4686 23.6163 17.0861 23.1429 17.0861H0.857143C0.383732 17.0861 0 17.4686 0 17.9404V20.0762C0 20.548 0.383732 20.9305 0.857143 20.9305Z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
+      background-position: center !important;
+      background-repeat: no-repeat !important;
+      width: auto;
+      height: 35px;
+
+      &[aria-expanded="true"] {
+        background-image: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__close' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' aria-hidden='true' focusable='false'%3E%3Cpath d='M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
+      }
   }
 
   .nhsuk-header__search-toggle {
@@ -119,7 +124,7 @@
     height: 35px;
 
     span {
-      padding-top: 28px;
+      padding-top: 31px;
       display: block;
       font-weight: normal;
     }

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -50,10 +50,24 @@
     border-radius: $nhsuk-border-radius 0 0 $nhsuk-border-radius;
     border: $nhsuk-border-width-form-element solid $color_nhsuk-grey-2;
     border-right: none;
+    height: 40px;
+
+    &:focus {
+      border: 3px solid $color_marine-blue;
+      background: #D9F1F0 !important;
+      box-shadow: 0 0 0 1px #fff;
+    }
+
+    &:active {
+      border: 3px solid $color_marine-blue;
+      background: #D9F1F0 !important;
+      box-shadow: 0 0 0 1px #fff;
+    }
   }
 
   & .nhsuk-header__search-form button.nhsuk-search__submit {
     background-color: $color_southsea-blue;
+    height: 40px;
 
     svg {
       fill: $color_snow_white;
@@ -69,6 +83,10 @@
       & path {
         fill: $color_snow_white;
       }
+    }
+
+    &:focus, &:active {
+      box-shadow: 0 0 0 1px #fff;
     }
 
     &:active {

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -52,6 +52,32 @@
     border-right: none;
   }
 
+  & .nhsuk-header__search-form button.nhsuk-search__submit {
+    background-color: $color_southsea-blue;
+
+    svg {
+      fill: $color_snow_white;
+      height: 27px;
+      width: 27px;
+    }
+
+    &:focus, &:hover {
+      background-color: $color_marine-blue;
+      background: $color_marine-blue;
+      fill: $color_snow_white;
+
+      & path {
+        fill: $color_snow_white;
+      }
+    }
+
+    &:active {
+        background-color:#403DD0;
+        fill: $color_snow_white;
+        top: 0;
+    }
+  }
+
   &.nhsuk-header--white {
     .nhsuk-header__search-wrap input[type="text"] {
       border: $nhsuk-border-width-form-element solid $nhsuk-border-color;
@@ -307,7 +333,7 @@
   }
 }
 
-
+/* Styles for the search page's search */
 div.nhsuk-header__search--results-page {
 	float: unset;
   margin-left: 0;
@@ -348,7 +374,7 @@ div.nhsuk-header__search--results-page {
 
 	& .nhsuk-search__submit {
 		float: right !important;
-		margin-top: 0 !important;
+    margin-top: 0 !important;
     background-color: $color_southsea-blue;
 
     @include mq($until: tablet) {

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -96,6 +96,39 @@
     }
   }
 
+  .nhsuk-header__menu-toggle {
+    border: none;
+
+    svg {
+      display: none;
+
+      @include mq($until: tablet) {
+        display: block;
+        text-align: center;
+        margin: 0 auto;
+      }
+    }
+  }
+
+  .nhsuk-header__search-toggle {
+    border: none;
+    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__search' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' aria-hidden='true' focusable='false'%3E%3Cpath d='M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
+    background-position: center !important;
+    background-repeat: no-repeat !important;
+    width: auto;
+    height: 35px;
+
+    span {
+      padding-top: 28px;
+      display: block;
+      font-weight: normal;
+    }
+
+    &[aria-expanded="true"] {
+      background-image: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__close' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' aria-hidden='true' focusable='false'%3E%3Cpath d='M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
+    }
+  }
+
   &.nhsuk-header--white {
     .nhsuk-header__search-wrap input[type="text"] {
       border: $nhsuk-border-width-form-element solid $nhsuk-border-color;

--- a/header.php
+++ b/header.php
@@ -68,12 +68,8 @@ echo '<header class="nhsuk-header nhsuk-header--' . esc_attr( $header_layout . $
         if ($show_header_menu == 'yes') {
             ?>
             <div class="nhsuk-header__menu <?php echo esc_attr($headersearchextra); ?>">
-                <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation"
-												aria-label="Open menu">
-												<svg width="24" height="21" viewBox="0 0 24 21" fill="none" xmlns="http://www.w3.org/2000/svg">
-												<path d="M0.857143 3.84437H23.1429C23.6163 3.84437 24 3.46191 24 2.99007V0.854305C24 0.382462 23.6163 0 23.1429 0H0.857143C0.383732 0 0 0.382462 0 0.854305V2.99007C0 3.46191 0.383732 3.84437 0.857143 3.84437ZM0.857143 12.3874H23.1429C23.6163 12.3874 24 12.005 24 11.5331V9.39735C24 8.92551 23.6163 8.54305 23.1429 8.54305H0.857143C0.383732 8.54305 0 8.92551 0 9.39735V11.5331C0 12.005 0.383732 12.3874 0.857143 12.3874ZM0.857143 20.9305H23.1429C23.6163 20.9305 24 20.548 24 20.0762V17.9404C24 17.4686 23.6163 17.0861 23.1429 17.0861H0.857143C0.383732 17.0861 0 17.4686 0 17.9404V20.0762C0 20.548 0.383732 20.9305 0.857143 20.9305Z" fill="white"/>
-												</svg>
-												Menu
+                <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">
+									<span>Menu</span>
                 </button>
             </div>
 

--- a/header.php
+++ b/header.php
@@ -69,7 +69,11 @@ echo '<header class="nhsuk-header nhsuk-header--' . esc_attr( $header_layout . $
             ?>
             <div class="nhsuk-header__menu <?php echo esc_attr($headersearchextra); ?>">
                 <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation"
-                        aria-label="Open menu">Menu
+												aria-label="Open menu">
+												<svg width="24" height="21" viewBox="0 0 24 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+												<path d="M0.857143 3.84437H23.1429C23.6163 3.84437 24 3.46191 24 2.99007V0.854305C24 0.382462 23.6163 0 23.1429 0H0.857143C0.383732 0 0 0.382462 0 0.854305V2.99007C0 3.46191 0.383732 3.84437 0.857143 3.84437ZM0.857143 12.3874H23.1429C23.6163 12.3874 24 12.005 24 11.5331V9.39735C24 8.92551 23.6163 8.54305 23.1429 8.54305H0.857143C0.383732 8.54305 0 8.92551 0 9.39735V11.5331C0 12.005 0.383732 12.3874 0.857143 12.3874ZM0.857143 20.9305H23.1429C23.6163 20.9305 24 20.548 24 20.0762V17.9404C24 17.4686 23.6163 17.0861 23.1429 17.0861H0.857143C0.383732 17.0861 0 17.4686 0 17.9404V20.0762C0 20.548 0.383732 20.9305 0.857143 20.9305Z" fill="white"/>
+												</svg>
+												Menu
                 </button>
             </div>
 

--- a/searchform.php
+++ b/searchform.php
@@ -20,14 +20,12 @@ if ( ! isset( $GLOBALS['nightingale_search_form_counter'] ) ) {
 	$wrap_search                                = 'id=wrap-search';
 	$search_form                                = 'id=search';
 	$search_field                               = 'search-field';
-	$autocomplete                               = 'id=autocomplete-container';
 	$close_search                               = 'id=close-search';
 } else {
 	$GLOBALS['nightingale_search_form_counter'] ++;
 	$searchid      = $GLOBALS['nightingale_search_form_counter'];
 	$toggle_search = '';
 	$wrap_search   = '';
-	$autocomplete  = '';
 	$close_search  = '';
 	$search_form   = 'id=search' . $searchid . '';
 	$search_field  = 'search-field' . $searchid;
@@ -43,8 +41,7 @@ if ( ! isset( $GLOBALS['nightingale_search_form_counter'] ) ) {
 <div class="nhsuk-header__search-wrap" <?php echo esc_attr( $wrap_search ); ?>>
 	<form class="nhsuk-header__search-form" <?php echo esc_attr( $search_form ); ?> action="<?php echo esc_url( home_url( '/' ) ); ?>" method="get" role="search">
 		<label class="nhsuk-u-visually-hidden" for="<?php echo esc_attr( $search_field ); ?>"><?php esc_html_e( 'Search this website', 'nightingale' ); ?></label>
-		<div class="autocomplete-container" <?php echo esc_attr( $autocomplete ); ?>></div>
-		<input class="nhsuk-search__input" id="<?php echo esc_attr( $search_field ); ?>" name="s" type="search" placeholder="<?php echo esc_attr__( 'Search', 'nightingale' ); ?>" autocomplete="off">
+		<input class="nhsuk-search__input" id="<?php echo esc_attr( $search_field ); ?>" name="s" type="search" placeholder="<?php echo esc_attr__( 'Search', 'nightingale' ); ?>">
 		<button class="nhsuk-search__submit" type="submit">
 			<svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 				<path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>

--- a/searchform.php
+++ b/searchform.php
@@ -33,10 +33,7 @@ if ( ! isset( $GLOBALS['nightingale_search_form_counter'] ) ) {
 
 ?>
 <button class="nhsuk-header__search-toggle" <?php echo esc_attr( $toggle_search ); ?> aria-controls="search" aria-label="Open search" aria-expanded="false">
-	<svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-		<path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
-	</svg>
-	<span class="nhsuk-u-visually-hidden"><?php echo esc_html__( 'Search', 'nightingale' ); ?></span>
+	<span><?php echo esc_html__( 'Search', 'nightingale' ); ?></span>
 </button>
 <div class="nhsuk-header__search-wrap" <?php echo esc_attr( $wrap_search ); ?>>
 	<form class="nhsuk-header__search-form" <?php echo esc_attr( $search_form ); ?> action="<?php echo esc_url( home_url( '/' ) ); ?>" method="get" role="search">

--- a/style.css
+++ b/style.css
@@ -10716,10 +10716,24 @@ textarea:focus, #login #loginform .user-login:focus, #login #loginform .user_pas
   border-radius: 4px 0 0 4px;
   border: 2px solid #768692;
   border-right: none;
+  height: 40px;
+}
+
+.nhsuk-header .nhsuk-search__input:focus {
+  border: 3px solid #0D47A1;
+  background: #D9F1F0 !important;
+  box-shadow: 0 0 0 1px #fff;
+}
+
+.nhsuk-header .nhsuk-search__input:active {
+  border: 3px solid #0D47A1;
+  background: #D9F1F0 !important;
+  box-shadow: 0 0 0 1px #fff;
 }
 
 .nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit {
   background-color: #1976D2;
+  height: 40px;
 }
 
 .nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit svg {
@@ -10736,6 +10750,10 @@ textarea:focus, #login #loginform .user-login:focus, #login #loginform .user_pas
 
 .nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit:focus path, .nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit:hover path {
   fill: #FFFFFF;
+}
+
+.nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit:focus, .nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit:active {
+  box-shadow: 0 0 0 1px #fff;
 }
 
 .nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit:active {

--- a/style.css
+++ b/style.css
@@ -10718,6 +10718,32 @@ textarea:focus, #login #loginform .user-login:focus, #login #loginform .user_pas
   border-right: none;
 }
 
+.nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit {
+  background-color: #1976D2;
+}
+
+.nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit svg {
+  fill: #FFFFFF;
+  height: 27px;
+  width: 27px;
+}
+
+.nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit:focus, .nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit:hover {
+  background-color: #0D47A1;
+  background: #0D47A1;
+  fill: #FFFFFF;
+}
+
+.nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit:focus path, .nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit:hover path {
+  fill: #FFFFFF;
+}
+
+.nhsuk-header .nhsuk-header__search-form button.nhsuk-search__submit:active {
+  background-color: #403DD0;
+  fill: #FFFFFF;
+  top: 0;
+}
+
 .nhsuk-header.nhsuk-header--white .nhsuk-header__search-wrap input[type="text"] {
   border: 2px solid #d8dde0;
 }
@@ -10950,6 +10976,7 @@ textarea:focus, #login #loginform .user-login:focus, #login #loginform .user_pas
   }
 }
 
+/* Styles for the search page's search */
 div.nhsuk-header__search--results-page {
   float: unset;
   margin-left: 0;
@@ -11405,13 +11432,6 @@ span.search-terms {
   margin-bottom: 1rem;
 }
 
-.page .page-header .category-pages-nav, .search-page .page-header .category-pages-nav {
-  list-style: none;
-  padding: 0;
-  font-size: 16px;
-  font-size: 1rem;
-}
-
 .page .page-header .nhsuk-grid-column-two-thirds, .page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .page .page-header div.nhsuk-header__search-wrap, .search-page .page-header .nhsuk-grid-column-two-thirds, .search-page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-header__search-wrap {
   padding: 0;
 }
@@ -11420,6 +11440,13 @@ span.search-terms {
   .page .page-header .nhsuk-grid-column-two-thirds, .page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .page .page-header div.nhsuk-header__search-wrap, .search-page .page-header .nhsuk-grid-column-two-thirds, .search-page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-header__search-wrap {
     padding: 0 16px;
   }
+}
+
+.page .page-header .category-pages-nav, .search-page .page-header .category-pages-nav {
+  list-style: none;
+  padding: 0;
+  font-size: 16px;
+  font-size: 1rem;
 }
 
 .page .page-header .category-pages-nav .current_page, .search-page .page-header .category-pages-nav .current_page {

--- a/style.css
+++ b/style.css
@@ -10762,20 +10762,23 @@ textarea:focus, #login #loginform .user-login:focus, #login #loginform .user_pas
   top: 0;
 }
 
-.nhsuk-header .nhsuk-header__menu-toggle {
+.nhsuk-header .nhsuk-header__menu-toggle, .nhsuk-header .nhsuk-header__menu-toggle:hover {
   border: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='24' height='21' viewBox='0 0 24 21' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.857143 3.84437H23.1429C23.6163 3.84437 24 3.46191 24 2.99007V0.854305C24 0.382462 23.6163 0 23.1429 0H0.857143C0.383732 0 0 0.382462 0 0.854305V2.99007C0 3.46191 0.383732 3.84437 0.857143 3.84437ZM0.857143 12.3874H23.1429C23.6163 12.3874 24 12.005 24 11.5331V9.39735C24 8.92551 23.6163 8.54305 23.1429 8.54305H0.857143C0.383732 8.54305 0 8.92551 0 9.39735V11.5331C0 12.005 0.383732 12.3874 0.857143 12.3874ZM0.857143 20.9305H23.1429C23.6163 20.9305 24 20.548 24 20.0762V17.9404C24 17.4686 23.6163 17.0861 23.1429 17.0861H0.857143C0.383732 17.0861 0 17.4686 0 17.9404V20.0762C0 20.548 0.383732 20.9305 0.857143 20.9305Z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
+  background-position: center !important;
+  background-repeat: no-repeat !important;
+  width: auto;
+  height: 35px;
 }
 
-.nhsuk-header .nhsuk-header__menu-toggle svg {
-  display: none;
+.nhsuk-header .nhsuk-header__menu-toggle span, .nhsuk-header .nhsuk-header__menu-toggle:hover span {
+  padding-top: 28px;
+  display: block;
+  font-weight: normal;
 }
 
-@media (max-width: 40.0525em) {
-  .nhsuk-header .nhsuk-header__menu-toggle svg {
-    display: block;
-    text-align: center;
-    margin: 0 auto;
-  }
+.nhsuk-header .nhsuk-header__menu-toggle[aria-expanded="true"], .nhsuk-header .nhsuk-header__menu-toggle:hover[aria-expanded="true"] {
+  background-image: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__close' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' aria-hidden='true' focusable='false'%3E%3Cpath d='M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
 }
 
 .nhsuk-header .nhsuk-header__search-toggle {
@@ -10788,7 +10791,7 @@ textarea:focus, #login #loginform .user-login:focus, #login #loginform .user_pas
 }
 
 .nhsuk-header .nhsuk-header__search-toggle span {
-  padding-top: 28px;
+  padding-top: 31px;
   display: block;
   font-weight: normal;
 }

--- a/style.css
+++ b/style.css
@@ -10762,6 +10762,41 @@ textarea:focus, #login #loginform .user-login:focus, #login #loginform .user_pas
   top: 0;
 }
 
+.nhsuk-header .nhsuk-header__menu-toggle {
+  border: none;
+}
+
+.nhsuk-header .nhsuk-header__menu-toggle svg {
+  display: none;
+}
+
+@media (max-width: 40.0525em) {
+  .nhsuk-header .nhsuk-header__menu-toggle svg {
+    display: block;
+    text-align: center;
+    margin: 0 auto;
+  }
+}
+
+.nhsuk-header .nhsuk-header__search-toggle {
+  border: none;
+  background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__search' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' aria-hidden='true' focusable='false'%3E%3Cpath d='M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
+  background-position: center !important;
+  background-repeat: no-repeat !important;
+  width: auto;
+  height: 35px;
+}
+
+.nhsuk-header .nhsuk-header__search-toggle span {
+  padding-top: 28px;
+  display: block;
+  font-weight: normal;
+}
+
+.nhsuk-header .nhsuk-header__search-toggle[aria-expanded="true"] {
+  background-image: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__close' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' aria-hidden='true' focusable='false'%3E%3Cpath d='M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
+}
+
 .nhsuk-header.nhsuk-header--white .nhsuk-header__search-wrap input[type="text"] {
   border: 2px solid #d8dde0;
 }


### PR DESCRIPTION
This PR focuses on the navbar focus states and icons on toggle. Now, the hamburger and search icon toggle to cross on mobile when pressed. This is linked to `aria-expanded`, so we know that it should also be being announced to screen reader users.

There are a couple of further tweaks to make (making sure screen reader users hear that the button now means close and not open, mobile button focus states_, but this is the bulk of the visual styling work on this component. 