### PR TITLE
Add in ARIA to toggle button text between close and open

### DIFF
--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -19,6 +19,11 @@
     }
   }
 
+  .nhsuk-header__search-wrap.js-show {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
   .nhsuk-header__search-wrap input[type="text"] {
     border-radius: $nhsuk-border-radius 0px 0px $nhsuk-border-radius;
     border: none;
@@ -44,6 +49,10 @@
       color: $color_nhsuk-white;
     }
 
+  }
+
+  .nhsuk-search__close {
+    display: none;
   }
 
   .nhsuk-search__input {
@@ -96,7 +105,7 @@
     }
   }
 
-  .nhsuk-header__menu-toggle, .nhsuk-header__menu-toggle:hover {
+  .nhsuk-header__menu-toggle {
     border: none;
 
     span {
@@ -109,9 +118,14 @@
       background-repeat: no-repeat !important;
       width: auto;
       height: 35px;
+      border: 2px solid transparent;
 
       &[aria-expanded="true"] {
         background-image: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__close' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' aria-hidden='true' focusable='false'%3E%3Cpath d='M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
+      }
+
+      &:hover, &:focus {
+        border: 2px solid $color_nhsuk-white;
       }
   }
 
@@ -122,6 +136,7 @@
     background-repeat: no-repeat !important;
     width: auto;
     height: 35px;
+    border: 2px solid transparent;
 
     span {
       padding-top: 31px;
@@ -131,6 +146,10 @@
 
     &[aria-expanded="true"] {
       background-image: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__close' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' aria-hidden='true' focusable='false'%3E%3Cpath d='M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
+    }
+
+    &:hover, &:focus {
+      border: 2px solid $color_nhsuk-white;
     }
   }
 

--- a/header.php
+++ b/header.php
@@ -68,7 +68,7 @@ echo '<header class="nhsuk-header nhsuk-header--' . esc_attr( $header_layout . $
         if ($show_header_menu == 'yes') {
             ?>
             <div class="nhsuk-header__menu <?php echo esc_attr($headersearchextra); ?>">
-                <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">
+                <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu" aria-expanded="false">
 									<span>Menu</span>
                 </button>
             </div>

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -4,7 +4,28 @@
  * Handles toggling the navigation menu for small screens and enables TAB key
  * navigation support for dropdown menus.
  */
+
 ( function() {
+
+	const searchToggleButton = document.getElementById('toggle-search');
+	const menuToggleButton = document.getElementById('toggle-menu');
+
+	searchToggleButton.onclick = function () {
+		if (searchToggleButton.getAttribute("aria-expanded") === "false") {
+			searchToggleButton.setAttribute("aria-label", "Close search");
+		} else {
+			searchToggleButton.setAttribute("aria-label", "Open search");
+		}
+	}
+
+	menuToggleButton.onclick = function () {
+		if (menuToggleButton.getAttribute("aria-expanded") === "false") {
+			menuToggleButton.setAttribute("aria-label", "Close menu");
+		} else {
+			menuToggleButton.setAttribute("aria-label", "Open menu");
+		}
+	}
+
 	var container, button, menu, links, i, len;
 
 	container = document.getElementById( 'site-navigation' );
@@ -125,4 +146,3 @@ function guideNavClick(id) {
 		document.getElementById(id).style.display = "block";
 	}
 }
-

--- a/style.css
+++ b/style.css
@@ -10689,6 +10689,11 @@ textarea:focus, #login #loginform .user-login:focus, #login #loginform .user_pas
   padding: 8px 0;
 }
 
+.nhsuk-header .nhsuk-header__search-wrap.js-show {
+  margin-left: 0;
+  margin-right: 0;
+}
+
 .nhsuk-header .nhsuk-header__search-wrap input[type="text"] {
   border-radius: 4px 0px 0px 4px;
   border: none;
@@ -10710,6 +10715,10 @@ textarea:focus, #login #loginform .user-login:focus, #login #loginform .user_pas
   text-decoration: none;
   background-color: transparent;
   color: #ffffff;
+}
+
+.nhsuk-header .nhsuk-search__close {
+  display: none;
 }
 
 .nhsuk-header .nhsuk-search__input {
@@ -10762,23 +10771,28 @@ textarea:focus, #login #loginform .user-login:focus, #login #loginform .user_pas
   top: 0;
 }
 
-.nhsuk-header .nhsuk-header__menu-toggle, .nhsuk-header .nhsuk-header__menu-toggle:hover {
+.nhsuk-header .nhsuk-header__menu-toggle {
   border: none;
   background-image: url("data:image/svg+xml,%3Csvg width='24' height='21' viewBox='0 0 24 21' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0.857143 3.84437H23.1429C23.6163 3.84437 24 3.46191 24 2.99007V0.854305C24 0.382462 23.6163 0 23.1429 0H0.857143C0.383732 0 0 0.382462 0 0.854305V2.99007C0 3.46191 0.383732 3.84437 0.857143 3.84437ZM0.857143 12.3874H23.1429C23.6163 12.3874 24 12.005 24 11.5331V9.39735C24 8.92551 23.6163 8.54305 23.1429 8.54305H0.857143C0.383732 8.54305 0 8.92551 0 9.39735V11.5331C0 12.005 0.383732 12.3874 0.857143 12.3874ZM0.857143 20.9305H23.1429C23.6163 20.9305 24 20.548 24 20.0762V17.9404C24 17.4686 23.6163 17.0861 23.1429 17.0861H0.857143C0.383732 17.0861 0 17.4686 0 17.9404V20.0762C0 20.548 0.383732 20.9305 0.857143 20.9305Z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
   background-position: center !important;
   background-repeat: no-repeat !important;
   width: auto;
   height: 35px;
+  border: 2px solid transparent;
 }
 
-.nhsuk-header .nhsuk-header__menu-toggle span, .nhsuk-header .nhsuk-header__menu-toggle:hover span {
+.nhsuk-header .nhsuk-header__menu-toggle span {
   padding-top: 28px;
   display: block;
   font-weight: normal;
 }
 
-.nhsuk-header .nhsuk-header__menu-toggle[aria-expanded="true"], .nhsuk-header .nhsuk-header__menu-toggle:hover[aria-expanded="true"] {
+.nhsuk-header .nhsuk-header__menu-toggle[aria-expanded="true"] {
   background-image: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__close' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' aria-hidden='true' focusable='false'%3E%3Cpath d='M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
+}
+
+.nhsuk-header .nhsuk-header__menu-toggle:hover, .nhsuk-header .nhsuk-header__menu-toggle:focus {
+  border: 2px solid #ffffff;
 }
 
 .nhsuk-header .nhsuk-header__search-toggle {
@@ -10788,6 +10802,7 @@ textarea:focus, #login #loginform .user-login:focus, #login #loginform .user_pas
   background-repeat: no-repeat !important;
   width: auto;
   height: 35px;
+  border: 2px solid transparent;
 }
 
 .nhsuk-header .nhsuk-header__search-toggle span {
@@ -10798,6 +10813,10 @@ textarea:focus, #login #loginform .user-login:focus, #login #loginform .user_pas
 
 .nhsuk-header .nhsuk-header__search-toggle[aria-expanded="true"] {
   background-image: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__close' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' aria-hidden='true' focusable='false'%3E%3Cpath d='M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z' fill='white'%3E%3C/path%3E%3C/svg%3E") !important;
+}
+
+.nhsuk-header .nhsuk-header__search-toggle:hover, .nhsuk-header .nhsuk-header__search-toggle:focus {
+  border: 2px solid #ffffff;
 }
 
 .nhsuk-header.nhsuk-header--white .nhsuk-header__search-wrap input[type="text"] {


### PR DESCRIPTION
When you open the menu button, the open button becomes the close button. This was conveyed visually with the close icon, but there wasn't anything for screen reader users.

This adds in text that a screen reader user will here, that switches between 'close menu' and 'open menu', so DAC can test on Monday