### PR TITLE
Add in flex for sticky footer

### DIFF
--- a/assets/scss/footer.scss
+++ b/assets/scss/footer.scss
@@ -49,3 +49,27 @@
 		}
 	}
 }
+
+// Sticky footer, for browsers that support it
+@supports (display: flex) {
+	html, body {
+		height: 100%;
+	}
+
+	body {
+		display: flex;
+		flex-direction: column;
+	}
+
+	#content {
+		flex: 1 0 auto;
+
+		@media (min-width: 1024px) {
+			width: 100%;
+		}
+	}
+
+	footer {
+		flex-shrink: 0;
+	}
+}

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 1.0.2
+Version: 1.0.6
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson & Robert Lowe
 */

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 1.0.5
+Version: 1.0.2
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson & Robert Lowe
 */
@@ -10730,6 +10730,27 @@ div.nhsuk-header__search--results-page .nhsuk-search__submit:active {
 .nhsuk-footer .widget_social_widget .widgettitle {
   font-size: 24px;
   font-size: 1.5rem;
+}
+
+@supports (display: flex) {
+  html, body {
+    height: 100%;
+  }
+  body {
+    display: flex;
+    flex-direction: column;
+  }
+  #content {
+    flex: 1 0 auto;
+  }
+  @media (min-width: 1024px) {
+    #content {
+      width: 100%;
+    }
+  }
+  footer {
+    flex-shrink: 0;
+  }
 }
 
 /* Style Variation - Overrides NHS DS Frontend styles */


### PR DESCRIPTION
This adds in some flex CSS, for browsers that can support it. It makes the footer stick to the bottom of the page, when there's not enough content to push it down. It hooks onto the footer element and the diev with an id of 'content', which are both put in there by the hale theme itself.