### PR TITLE
Add proper focus state to search page search button and bring in line

### DIFF
--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -438,7 +438,7 @@ div.nhsuk-header__search--results-page {
 		}
   }
 
-  & div.nhsuk-header__search-wrap {
+  & div.nhsuk-header__search-wrap#wrap-search {
     @extend .nhsuk-grid-column-two-thirds;
     padding: 0;
   }
@@ -488,9 +488,14 @@ div.nhsuk-header__search--results-page {
     }
 
     &:active {
-        background-color:#403DD0;
-        fill: $color_snow-white;
-        top: 0;
+      background-color:#403DD0;
+      fill: $color_snow-white;
+      top: 0;
+    }
+
+    &:focus, &:active {
+      box-shadow: 0 0 0 2px #fff,0 0 0 4px #00a0cc;
+      outline: none;
     }
 	}
 

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -438,7 +438,7 @@ div.nhsuk-header__search--results-page {
 		}
   }
 
-  & div.nhsuk-header__search-wrap#wrap-search {
+  & div.nhsuk-header__search-wrap {
     @extend .nhsuk-grid-column-two-thirds;
     padding: 0;
   }

--- a/assets/scss/search.scss
+++ b/assets/scss/search.scss
@@ -133,3 +133,7 @@
     }
   }
 }
+
+body.search.search-results div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search {
+  padding: 0;
+}

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 1.0.2
+Version: 1.0.6
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson & Robert Lowe
 */

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 1.0.7
+Version: 1.0.2
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson & Robert Lowe
 */
@@ -1054,13 +1054,13 @@ caption {
   }
 }
 
-.nhsuk-grid-column-two-thirds, div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search {
+.nhsuk-grid-column-two-thirds, div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap {
   box-sizing: border-box;
   padding: 0 16px;
 }
 
 @media (min-width: 48.0625em) {
-  .nhsuk-grid-column-two-thirds, div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search {
+  .nhsuk-grid-column-two-thirds, div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap {
     float: left;
     width: 66.6666%;
   }
@@ -10525,7 +10525,7 @@ div.nhsuk-header__search--results-page {
   }
 }
 
-div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search {
+div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap {
   padding: 0;
 }
 
@@ -10608,13 +10608,13 @@ div.nhsuk-header__search--results-page .nhsuk-search__submit:focus, div.nhsuk-he
 }
 
 @media (min-width: 40.0625em) {
-  .nightingale-banner__container .nhsuk-grid-column-two-thirds, .nightingale-banner__container div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search, div.nhsuk-header__search--results-page .nightingale-banner__container div.nhsuk-header__search-wrap#wrap-search {
+  .nightingale-banner__container .nhsuk-grid-column-two-thirds, .nightingale-banner__container div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .nightingale-banner__container div.nhsuk-header__search-wrap {
     padding: 0;
   }
 }
 
 @media (min-width: 40.0625em) and (min-width: 40.0625em) {
-  .nightingale-banner__container .nhsuk-grid-column-two-thirds, .nightingale-banner__container div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search, div.nhsuk-header__search--results-page .nightingale-banner__container div.nhsuk-header__search-wrap#wrap-search {
+  .nightingale-banner__container .nhsuk-grid-column-two-thirds, .nightingale-banner__container div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .nightingale-banner__container div.nhsuk-header__search-wrap {
     padding: 0;
   }
 }
@@ -10794,12 +10794,12 @@ a:visited {
   color: #000000;
 }
 
-.nhsuk-grid-column-two-thirds.contentright, div.nhsuk-header__search--results-page div.contentright.nhsuk-header__search-wrap#wrap-search {
+.nhsuk-grid-column-two-thirds.contentright, div.nhsuk-header__search--results-page div.contentright.nhsuk-header__search-wrap {
   float: right;
   padding: 0 16px 0 16px;
 }
 
-.nhsuk-grid-column-two-thirds.contentleft, div.nhsuk-header__search--results-page div.contentleft.nhsuk-header__search-wrap#wrap-search {
+.nhsuk-grid-column-two-thirds.contentleft, div.nhsuk-header__search--results-page div.contentleft.nhsuk-header__search-wrap {
   padding: 0 16px 0 16px;
 }
 
@@ -10856,9 +10856,9 @@ a:visited {
   color: #005eb8;
 }
 
-.nhsuk-grid-column-two-thirds.archive, div.nhsuk-header__search--results-page div.archive.nhsuk-header__search-wrap#wrap-search,
+.nhsuk-grid-column-two-thirds.archive, div.nhsuk-header__search--results-page div.archive.nhsuk-header__search-wrap,
 .nhsuk-grid-column-two-thirds.index,
-div.nhsuk-header__search--results-page div.index.nhsuk-header__search-wrap#wrap-search {
+div.nhsuk-header__search--results-page div.index.nhsuk-header__search-wrap {
   padding: 0 16px 0 0;
 }
 
@@ -11005,18 +11005,18 @@ span.search-terms {
   margin-bottom: 1rem;
 }
 
-.page .page-header .nhsuk-grid-column-two-thirds, .page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search, div.nhsuk-header__search--results-page .page .page-header div.nhsuk-header__search-wrap#wrap-search,
+.page .page-header .nhsuk-grid-column-two-thirds, .page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .page .page-header div.nhsuk-header__search-wrap,
 .search-page .page-header .nhsuk-grid-column-two-thirds,
-.search-page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search,
-div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-header__search-wrap#wrap-search {
+.search-page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap,
+div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-header__search-wrap {
   padding: 0;
 }
 
 @media (min-width: 40.0625em) {
-  .page .page-header .nhsuk-grid-column-two-thirds, .page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search, div.nhsuk-header__search--results-page .page .page-header div.nhsuk-header__search-wrap#wrap-search,
+  .page .page-header .nhsuk-grid-column-two-thirds, .page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .page .page-header div.nhsuk-header__search-wrap,
   .search-page .page-header .nhsuk-grid-column-two-thirds,
-  .search-page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search,
-  div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-header__search-wrap#wrap-search {
+  .search-page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap,
+  div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-header__search-wrap {
     padding: 0 16px;
   }
 }
@@ -11182,10 +11182,10 @@ div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-heade
 }
 
 @media (max-width: 40.0525em) {
-  .page .nhsuk-grid-column-two-thirds.contentleft, .page div.nhsuk-header__search--results-page div.contentleft.nhsuk-header__search-wrap#wrap-search, div.nhsuk-header__search--results-page .page div.contentleft.nhsuk-header__search-wrap#wrap-search,
+  .page .nhsuk-grid-column-two-thirds.contentleft, .page div.nhsuk-header__search--results-page div.contentleft.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .page div.contentleft.nhsuk-header__search-wrap,
   .search-page .nhsuk-grid-column-two-thirds.contentleft,
-  .search-page div.nhsuk-header__search--results-page div.contentleft.nhsuk-header__search-wrap#wrap-search,
-  div.nhsuk-header__search--results-page .search-page div.contentleft.nhsuk-header__search-wrap#wrap-search {
+  .search-page div.nhsuk-header__search--results-page div.contentleft.nhsuk-header__search-wrap,
+  div.nhsuk-header__search--results-page .search-page div.contentleft.nhsuk-header__search-wrap {
     padding: 0;
   }
 }

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 1.0.2
+Version: 1.0.7
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson & Robert Lowe
 */

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 1.0.6
+Version: 1.0.2
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson & Robert Lowe
 */
@@ -1054,13 +1054,13 @@ caption {
   }
 }
 
-.nhsuk-grid-column-two-thirds, div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap {
+.nhsuk-grid-column-two-thirds, div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search {
   box-sizing: border-box;
   padding: 0 16px;
 }
 
 @media (min-width: 48.0625em) {
-  .nhsuk-grid-column-two-thirds, div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap {
+  .nhsuk-grid-column-two-thirds, div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search {
     float: left;
     width: 66.6666%;
   }
@@ -10525,7 +10525,7 @@ div.nhsuk-header__search--results-page {
   }
 }
 
-div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap {
+div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search {
   padding: 0;
 }
 
@@ -10582,6 +10582,11 @@ div.nhsuk-header__search--results-page .nhsuk-search__submit:active {
   top: 0;
 }
 
+div.nhsuk-header__search--results-page .nhsuk-search__submit:focus, div.nhsuk-header__search--results-page .nhsuk-search__submit:active {
+  box-shadow: 0 0 0 2px #fff,0 0 0 4px #00a0cc;
+  outline: none;
+}
+
 @media (max-width: 40.0525em) {
   div.nhsuk-header__search--results-page .nhsuk-header__search-wrap {
     display: unset;
@@ -10603,13 +10608,13 @@ div.nhsuk-header__search--results-page .nhsuk-search__submit:active {
 }
 
 @media (min-width: 40.0625em) {
-  .nightingale-banner__container .nhsuk-grid-column-two-thirds, .nightingale-banner__container div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .nightingale-banner__container div.nhsuk-header__search-wrap {
+  .nightingale-banner__container .nhsuk-grid-column-two-thirds, .nightingale-banner__container div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search, div.nhsuk-header__search--results-page .nightingale-banner__container div.nhsuk-header__search-wrap#wrap-search {
     padding: 0;
   }
 }
 
 @media (min-width: 40.0625em) and (min-width: 40.0625em) {
-  .nightingale-banner__container .nhsuk-grid-column-two-thirds, .nightingale-banner__container div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .nightingale-banner__container div.nhsuk-header__search-wrap {
+  .nightingale-banner__container .nhsuk-grid-column-two-thirds, .nightingale-banner__container div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search, div.nhsuk-header__search--results-page .nightingale-banner__container div.nhsuk-header__search-wrap#wrap-search {
     padding: 0;
   }
 }
@@ -10789,12 +10794,12 @@ a:visited {
   color: #000000;
 }
 
-.nhsuk-grid-column-two-thirds.contentright, div.nhsuk-header__search--results-page div.contentright.nhsuk-header__search-wrap {
+.nhsuk-grid-column-two-thirds.contentright, div.nhsuk-header__search--results-page div.contentright.nhsuk-header__search-wrap#wrap-search {
   float: right;
   padding: 0 16px 0 16px;
 }
 
-.nhsuk-grid-column-two-thirds.contentleft, div.nhsuk-header__search--results-page div.contentleft.nhsuk-header__search-wrap {
+.nhsuk-grid-column-two-thirds.contentleft, div.nhsuk-header__search--results-page div.contentleft.nhsuk-header__search-wrap#wrap-search {
   padding: 0 16px 0 16px;
 }
 
@@ -10851,9 +10856,9 @@ a:visited {
   color: #005eb8;
 }
 
-.nhsuk-grid-column-two-thirds.archive, div.nhsuk-header__search--results-page div.archive.nhsuk-header__search-wrap,
+.nhsuk-grid-column-two-thirds.archive, div.nhsuk-header__search--results-page div.archive.nhsuk-header__search-wrap#wrap-search,
 .nhsuk-grid-column-two-thirds.index,
-div.nhsuk-header__search--results-page div.index.nhsuk-header__search-wrap {
+div.nhsuk-header__search--results-page div.index.nhsuk-header__search-wrap#wrap-search {
   padding: 0 16px 0 0;
 }
 
@@ -11000,18 +11005,18 @@ span.search-terms {
   margin-bottom: 1rem;
 }
 
-.page .page-header .nhsuk-grid-column-two-thirds, .page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .page .page-header div.nhsuk-header__search-wrap,
+.page .page-header .nhsuk-grid-column-two-thirds, .page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search, div.nhsuk-header__search--results-page .page .page-header div.nhsuk-header__search-wrap#wrap-search,
 .search-page .page-header .nhsuk-grid-column-two-thirds,
-.search-page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap,
-div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-header__search-wrap {
+.search-page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search,
+div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-header__search-wrap#wrap-search {
   padding: 0;
 }
 
 @media (min-width: 40.0625em) {
-  .page .page-header .nhsuk-grid-column-two-thirds, .page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .page .page-header div.nhsuk-header__search-wrap,
+  .page .page-header .nhsuk-grid-column-two-thirds, .page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search, div.nhsuk-header__search--results-page .page .page-header div.nhsuk-header__search-wrap#wrap-search,
   .search-page .page-header .nhsuk-grid-column-two-thirds,
-  .search-page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap,
-  div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-header__search-wrap {
+  .search-page .page-header div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search,
+  div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-header__search-wrap#wrap-search {
     padding: 0 16px;
   }
 }
@@ -11177,10 +11182,10 @@ div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-heade
 }
 
 @media (max-width: 40.0525em) {
-  .page .nhsuk-grid-column-two-thirds.contentleft, .page div.nhsuk-header__search--results-page div.contentleft.nhsuk-header__search-wrap, div.nhsuk-header__search--results-page .page div.contentleft.nhsuk-header__search-wrap,
+  .page .nhsuk-grid-column-two-thirds.contentleft, .page div.nhsuk-header__search--results-page div.contentleft.nhsuk-header__search-wrap#wrap-search, div.nhsuk-header__search--results-page .page div.contentleft.nhsuk-header__search-wrap#wrap-search,
   .search-page .nhsuk-grid-column-two-thirds.contentleft,
-  .search-page div.nhsuk-header__search--results-page div.contentleft.nhsuk-header__search-wrap,
-  div.nhsuk-header__search--results-page .search-page div.contentleft.nhsuk-header__search-wrap {
+  .search-page div.nhsuk-header__search--results-page div.contentleft.nhsuk-header__search-wrap#wrap-search,
+  div.nhsuk-header__search--results-page .search-page div.contentleft.nhsuk-header__search-wrap#wrap-search {
     padding: 0;
   }
 }
@@ -11338,6 +11343,10 @@ div.nhsuk-header__search--results-page .search-page .page-header div.nhsuk-heade
 
 .search__pagination-button--next a {
   float: right;
+}
+
+body.search.search-results div.nhsuk-header__search--results-page div.nhsuk-header__search-wrap#wrap-search {
+  padding: 0;
 }
 
 #secondary section {

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 1.0.6
+Version: 1.0.7
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson & Robert Lowe
 */


### PR DESCRIPTION
The search bar button on the search bar didn't have the right focus states. This brings that in. It also shunts the bar to the left slightly, so it's in line with the rest of the page content.