### PR TITLE
Make sticky footer height vh not % to avoid background colour bug

### DIFF
--- a/assets/scss/footer.scss
+++ b/assets/scss/footer.scss
@@ -53,7 +53,7 @@
 // Sticky footer, for browsers that support it
 @supports (display: flex) {
 	html, body {
-		height: 100%;
+		min-height: 100vh;
 	}
 
 	body {

--- a/style.css
+++ b/style.css
@@ -10739,7 +10739,7 @@ div.nhsuk-header__search--results-page .nhsuk-search__submit:focus, div.nhsuk-he
 
 @supports (display: flex) {
   html, body {
-    height: 100%;
+    min-height: 100vh;
   }
   body {
     display: flex;


### PR DESCRIPTION
The `height: 100%` was causing issues for the background colour on pages with the minty background. The colour was taking browser height, not content height. `min-height` doesn't work in our use case with %, but it does with `vh`. This unit is supported at a similar rate to flex, and this is wrappered in a `@supports` for flex.