### PR TITLE
Make banner full width above 1024px (to prevent bug)

### DIFF
--- a/assets/scss/banner.scss
+++ b/assets/scss/banner.scss
@@ -1,6 +1,10 @@
 .nightingale-banner__container {
 	padding: 20px 0;
 
+	@media (min-width: 1024px) {
+		width: 100%;
+	}
+
 	.nhsuk-grid-column-two-thirds {
 		@include mq($from: tablet) {
 			@include nhsuk-responsive-padding(0);
@@ -21,7 +25,7 @@
 			float: right;
 		}
 	}
-	
+
 	.yellow-button {
 		background: $color_sunflower-yellow;
 		color: $color_charcoal-black;

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 1.0.9
+Version: 1.0.8
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson & Robert Lowe
 */
@@ -10605,6 +10605,12 @@ div.nhsuk-header__search--results-page .nhsuk-search__submit:focus, div.nhsuk-he
 /* end of header.scss include */
 .nightingale-banner__container {
   padding: 20px 0;
+}
+
+@media (min-width: 1024px) {
+  .nightingale-banner__container {
+    width: 100%;
+  }
 }
 
 @media (min-width: 40.0625em) {


### PR DESCRIPTION
This re-aligns the text in the call to action section in the header. 

I think we will need to add in another breakpoint in the future. The tablet variable is around 40rem (~640px) and the desktop variable is around 48rem (768px). This might be part of the discussions we have around frontend frameworks (we still need to choose one for Hale).