### PR TITLE
Add meta description tag, that links to the site tagline

### DIFF
--- a/header.php
+++ b/header.php
@@ -16,7 +16,8 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
-	<meta name="theme" content="NHS-nightingale-2.2.0">
+	<meta name="theme" content="MOJ-hale-1.0.11">
+	<meta name="description" content="<?php bloginfo('description'); ?>" />
 	<link rel="profile" href="https://gmpg.org/xfn/11">
 	<?php
 	wp_enqueue_script( 'jquery' );

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 1.0.10
+Version: 1.0.11
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson & Robert Lowe
 */

--- a/style.scss
+++ b/style.scss
@@ -2,7 +2,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 1.0.10
+Version: 1.0.11
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson & Robert Lowe
 */


### PR DESCRIPTION
Because the cookie banner comes naer the top of the DOM (for accessibility reasons), that text is currently being pulled out by google and shown in search results. This adds in a meta tag that pulls in the site tagline as the site description. This means this should show on google instead of the cookie info.

I've also updated the meta tag with the theme name in to say hale, instead of nightingale.

This is after discussion with Anna and Josh (Content Designers) to double check it's okay to use the tagline in this way, from their perspective.