### PR TITLE
Added styling for unclassed <ol> lists

### DIFF
--- a/assets/scss/moj-blocks-general.scss
+++ b/assets/scss/moj-blocks-general.scss
@@ -4,9 +4,15 @@
     @extend .govuk-link;
   }
   ul:not([class]), ul[class=""] {
-    //deals with any lists that aren't classed - makes them GDS links
+    //deals with any lists that aren't classed
     @extend .govuk-list;
     @extend .govuk-list--bullet;
+  }
+
+  ol:not([class]), ol[class=""] {
+    //deals with any numbered lists that aren't classed
+    @extend .govuk-list;
+    @extend .govuk-list--number;
   }
 
 	//override for the sovial media links (ootb wordpress)


### PR DESCRIPTION
Extends the GDS classes for ordered lists to all lists within the GDS wrapper without any other class.