### PR TITLE
Corrected focus box-shadow for social media links

### DIFF
--- a/assets/scss/page-colours.scss
+++ b/assets/scss/page-colours.scss
@@ -335,7 +335,7 @@ $brandings: (
     cat-nav-arrows: $colour_flame_orange,
     footer-border: $colour_pluto_grey,
     footer-background: $colour_cloudy_grey,
-    footer-link-focus-background: $colour_jade_green_tint,
+    footer-link-focus-background: $colour_flame_orange_tint,
     link: $colour_purple,
     link-visited: $colour_lavender,
     link-hover: $colour_indigo,


### PR DESCRIPTION
The box shadow for focus state for social media links on Pluto was still using the Neptune branding.  Fixed here.