### PR TITLE
News cpt tweak

### DIFF
--- a/inc/custom-post-types/cpt-news.php
+++ b/inc/custom-post-types/cpt-news.php
@@ -52,6 +52,10 @@ function hale_register_news_post_type()
         'exclude_from_search' => false,
         'publicly_queryable' => true,
         'capability_type' => 'page',
+        'rewrite' => array(
+            'slug' => 'news',
+            'with_front' => false
+        ),
     );
 
     //Check if post type is deactived

--- a/inc/restrict-blocks.php
+++ b/inc/restrict-blocks.php
@@ -41,7 +41,7 @@ function hale_allowed_block_types( $allowed_blocks ) {
 
 }
 
-add_filter( 'allowed_block_types', 'hale_allowed_block_types' );
+add_filter( 'allowed_block_types_all', 'hale_allowed_block_types' );
 
 function hale_restrict_embed_blocks() {
 


### PR DESCRIPTION
- WP 5.8 compatibility fix with hook.
- Rewrite CPT url path to remove /blog, so it has changed from /blog/news to just /news