### PR TITLE
Pluto styling tweaks

### DIFF
--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -257,16 +257,25 @@
 		#primary a:not([class]),
 		#primary a[class=""],
 		.hale-article-nav,
-		a.govuk-footer__link {
-
+		a.govuk-link,
+		a.govuk-footer__link,
+		.moj-pagination__link {
 			&:focus {
-        color: branded(link-focus);
+				color: branded(link-focus);
 				background-color: branded(link-focus-background);
 				box-shadow: 0 -2px branded(link-focus-background), 0 4px branded(link-focus-shadow);
 				outline: 4px solid transparent;
 			}
 		}
-		
+		a.govuk-breadcrumbs__link,
+		a.govuk-back-link {
+			&:focus {
+				background-color: branded(link-focus-background);
+				box-shadow: 0 -2px branded(link-focus-background), 0 4px branded(link-focus-shadow);
+				outline: 4px solid transparent;
+			}
+		}
+
 		//shading colour - set here and use @extend to shade elements below
 		.hale-shaded {
 			background-color:branded(title-shading);

--- a/assets/scss/gds-design-system-settings.scss
+++ b/assets/scss/gds-design-system-settings.scss
@@ -9,7 +9,9 @@ $govuk-font-family: 'PT Sans', sans-serif;
     //the full width cover images go slightly off the pagem this is the easiest fix.
     overflow-x: hidden;
   }
-  
+  .hale-search-header + div {
+		margin-top: 30px;
+	}
   #primary {
     font-family: $govuk-font-family;
 
@@ -73,6 +75,9 @@ $govuk-font-family: 'PT Sans', sans-serif;
 			}
 		}
 	}
+}
+.hale-search-header + div {
+  margin-top: 30px;
 }
 .hale-search-results__last-updated-date{
   color: $govuk-secondary-text-colour;

--- a/assets/scss/specific-brandings.scss
+++ b/assets/scss/specific-brandings.scss
@@ -63,12 +63,6 @@
 	.govuk-breadcrumbs__link,
 	.govuk-back-link {
 		@extend .govuk-link;
-		
-		&:focus {
-			background-color: $colour_turquoise_tint;
-			box-shadow: 0 -2px $colour_turquoise_tint, 0 4px $colour_turquoise;
-			outline: 4px solid transparent;
-		}
 	}
 
 	.govuk-footer__inline-list-item {

--- a/assets/scss/specific-brandings.scss
+++ b/assets/scss/specific-brandings.scss
@@ -83,3 +83,24 @@
 		}
 	}
 }
+
+/**********************
+    Pluto branding
+        CCRC
+**********************/
+.hale-branding--pluto {
+
+	.govuk-breadcrumbs__link,
+	.govuk-back-link {
+		
+		&:focus {
+			background-color: $colour_flame_orange_tint;
+			box-shadow: 0 -2px $colour_flame_orange_tint, 0 4px $colour_flame_orange;
+			outline: 4px solid transparent;
+		}
+	}
+
+	.hale-search-header + div {
+		margin-top: 30px;
+	}
+}

--- a/assets/scss/specific-brandings.scss
+++ b/assets/scss/specific-brandings.scss
@@ -71,36 +71,10 @@
 		}
 	}
 
-	.hale-search-header + div {
-		margin-top: 30px;
-	}
-
-
 	.govuk-footer__inline-list-item {
 		display: block;
 		@include govuk-media-query($from: tablet) {
 			display: inline-block;
 		}
-	}
-}
-
-/**********************
-    Pluto branding
-        CCRC
-**********************/
-.hale-branding--pluto {
-
-	.govuk-breadcrumbs__link,
-	.govuk-back-link {
-
-		&:focus {
-			background-color: $colour_flame_orange_tint;
-			box-shadow: 0 -2px $colour_flame_orange_tint, 0 4px $colour_flame_orange;
-			outline: 4px solid transparent;
-		}
-	}
-
-	.hale-search-header + div {
-		margin-top: 30px;
 	}
 }

--- a/assets/scss/specific-brandings.scss
+++ b/assets/scss/specific-brandings.scss
@@ -92,7 +92,7 @@
 
 	.govuk-breadcrumbs__link,
 	.govuk-back-link {
-		
+
 		&:focus {
 			background-color: $colour_flame_orange_tint;
 			box-shadow: 0 -2px $colour_flame_orange_tint, 0 4px $colour_flame_orange;

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 2.5.0
+Version: 2.5.1
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
- Added a gap betwixt the search box and the results heading.
- Added correct focus colouring for the breadcrumb links and other links with incorrect focus styling.