### PR TITLE
Focus filter for logo in Neptune and Uranus

### DIFF
--- a/assets/scss/specific-brandings.scss
+++ b/assets/scss/specific-brandings.scss
@@ -7,6 +7,10 @@
 	.govuk-header {
 		padding-bottom: 1em;
 
+		a:focus img {
+			filter: invert(1) hue-rotate(180deg);
+		}
+
 		.hale-header__logotype-text--custom {
 			font-weight: 400;
 			font-size: 22px;
@@ -48,9 +52,13 @@
 		outline-color: $colour_capri_teal;
 	}
 
-  .govuk-header .govuk-header__logo {
-    min-height: 49px;
-  }
+	.govuk-header .govuk-header__logo {
+		min-height: 49px;
+
+		a:focus img {
+			filter: invert(1) hue-rotate(180deg);
+		}
+	}
 
 	.govuk-breadcrumbs__link,
 	.govuk-back-link {


### PR DESCRIPTION
CSS addition - filter to alter colour of logo image when link is in focus state.
Neptune and Uranus only, so change made in `specific-brandings.scss`.