### PR TITLE
CSS changes

### DIFF
--- a/assets/scss/brandings-mojblocks.scss
+++ b/assets/scss/brandings-mojblocks.scss
@@ -150,6 +150,29 @@
       }
     }
 
+    //coloured divider bar above
+    .mojblocks-divider-bar-before,
+    .mojblocks-divider-bar-before-shaded {
+      margin-top: 1rem;
+      position: relative;
+
+      &:before { //bar
+        content: "";
+        width: 3.5rem;
+        height: 0.5rem;
+        position: absolute;
+        top: -1rem;
+        pointer-events: none;
+      }
+    }
+    //bar colour
+    .mojblocks-divider-bar-before-shaded:before {
+      background: branded(mojblocks-divider);
+    }
+    .mojblocks-divider-bar-before:before {
+      background: currentColor;
+    }
+
     //all buttons in blocks
     .mojblocks-button,
     a.mojblocks-button,

--- a/assets/scss/brandings-mojblocks.scss
+++ b/assets/scss/brandings-mojblocks.scss
@@ -51,24 +51,6 @@
       }
     }
 
-    //Banner Block
-    .mojblocks-banner {
-      .mojblocks-banner__button {
-        background-color: branded(mojblocks-banner-btn-bg);
-        color: branded(mojblocks-banner-btn-text);
-
-        &:hover {
-          background-color: branded(mojblocks-banner-btn-hover-bg);
-          color: branded(mojblocks-banner-btn-hover-text);
-        }
-
-        &:focus {
-          background-color: branded(mojblocks-banner-btn-focus-bg);
-          color: branded(mojblocks-banner-btn-focus-text);
-          outline: 3px solid branded(mojblocks-banner-btn-focus-outline);
-        }
-      }
-    }
     //CTA Block
     .wp-block-mojblocks-cta {
       background-color: branded(mojblocks-cta-bg);
@@ -80,23 +62,6 @@
 
       .mojblocks-cta__content p {
         color: branded(mojblocks-cta-text);
-      }
-
-      .mojblocks-button,
-      a.mojblocks-button {
-        background-color: branded(mojblocks-cta-btn-bg);
-        color: branded(mojblocks-cta-btn-text);
-
-         &:hover {
-          background-color: branded(mojblocks-cta-btn-hover-bg);
-          color: branded(mojblocks-cta-btn-hover-text);
-        }
-
-        &:focus {
-          background-color: branded(mojblocks-cta-btn-focus-bg);
-          color: branded(mojblocks-cta-btn-focus-text);
-          box-shadow: 0 0 0 3px branded(mojblocks-cta-btn-focus-outline);
-        }
       }
     }
 
@@ -185,6 +150,40 @@
       }
     }
 
+    //all buttons in blocks
+    .mojblocks-button,
+    a.mojblocks-button,
+    .govuk-button {
+			border:branded(button-border);
+			box-shadow: 0 1px 0 branded(button);
+			color:branded(button-text);
+			background-color:branded(button);
+			&:hover {
+				background-color: branded(button-hover);
+				color: branded(button-hover-text);
+				box-shadow: 0 1px 0 branded(button-hover);
+				border-color: branded(link-focus);
+				svg {
+					fill: branded(button-hover-text);
+				}
+			}
+			&:active {
+				background-color: branded(button-active);
+				box-shadow: none;
+			}
+			&:focus {
+				background-color: branded(button-focus);
+				color: branded(button-focus-text);
+				box-shadow: 0 0 0 3px branded(button-focus-outline);
+			}
+			&:focus:not(:active):not(:hover) {
+				background-color: branded(button-focus);
+				color: branded(button-focus-text);
+				box-shadow: 0 0 0 3px branded(button-focus-outline);
+			}
+			svg {
+				fill: branded(button-text);
+			}
+		}
   }
-
 }

--- a/assets/scss/brandings-mojblocks.scss
+++ b/assets/scss/brandings-mojblocks.scss
@@ -89,7 +89,7 @@
         }
 
         &:before {
-          background-color: branded(mojblocks-highlights-list-divider);
+          background-color: branded(mojblocks-divider);
         }
       }
     }
@@ -121,7 +121,7 @@
           color: branded(mojblocks-staggered-box-title);
 
           &:before {
-            background: branded(mojblocks-staggered-box-divider);
+            background: branded(mojblocks-divider);
           }
         }
 

--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -200,9 +200,9 @@
         }
 			}
 		}
-    .mojblocks-button,
-    a.mojblocks-button,
-    .govuk-button {
+		.mojblocks-button,
+		a.mojblocks-button,
+		.govuk-button {
 			border:branded(button-border);
 			box-shadow: 0 1px 0 branded(button);
 			color:branded(button-text);

--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -200,7 +200,9 @@
         }
 			}
 		}
-		.govuk-button {
+    .mojblocks-button,
+    a.mojblocks-button,
+    .govuk-button {
 			border:branded(button-border);
 			box-shadow: 0 1px 0 branded(button);
 			color:branded(button-text);
@@ -246,9 +248,7 @@
 
     .govuk-main-wrapper a:link:not([class]),
     .gem-c-pagination__link:link {
-
       color: branded(link);
-
 
       &:hover {
         color: branded(link-hover);

--- a/assets/scss/page-colours.scss
+++ b/assets/scss/page-colours.scss
@@ -90,6 +90,7 @@ $brandings: (
     button-focus-outline: $colour_gold_tint,
     button-active: $colour_earth_blue,
     button-border:none,
+    mojblocks-divider: $colour_earth_blue,
     mojblocks-accordion-section-title: $colour_sapphire_blue,
     mojblocks-accordion-section-title-hover: $colour_earth_blue,
     mojblocks-accordion-section-title-focus: $colour_earth_blue,
@@ -167,6 +168,7 @@ $brandings: (
     button-focus-outline: $colour_turquoise,
     button-active: $colour_bluebell_blue,
 		button-border:none,
+    mojblocks-divider: $colour_neptune_blue,
     mojblocks-accordion-section-title: $colour_lagoon_blue,
     mojblocks-accordion-section-title-hover: $colour_deep_sea_blue,
     mojblocks-accordion-section-title-focus: $colour_deep_sea_blue,
@@ -244,6 +246,7 @@ $brandings: (
     button-focus-outline: $colour_sunflower_yellow,
 		button-active: $colour_charcoal_black,
     button-border:none,
+    mojblocks-divider: $colour_sunflower_yellow,
     mojblocks-accordion-section-title: $colour_southsea_blue,
     mojblocks-accordion-section-title-hover: $colour_marine_blue,
     mojblocks-accordion-section-title-focus: $colour_charcoal_black,
@@ -324,6 +327,7 @@ $brandings: (
     button-text:govuk-colour("white"),
     button-hover-text:govuk-colour("white"),
     button-border:none,
+    mojblocks-divider: $colour_flame_orange,
     mojblocks-accordion-section-title: $colour_purple,
     mojblocks-accordion-section-title-hover: $colour_indigo,
     mojblocks-accordion-section-title-focus: $colour_indigo,
@@ -403,6 +407,7 @@ $brandings: (
     button-text:govuk-colour("white"),
     button-hover-text:govuk-colour("white"),
     button-border:none,
+    mojblocks-divider: $colour_magenta,
     mojblocks-accordion-section-title: $colour_magenta,
     mojblocks-accordion-section-title-hover: $colour_indigo,
     mojblocks-accordion-section-title-focus: $colour_indigo,
@@ -521,6 +526,9 @@ $brandings: (
 		button-border:
 
 		//MOJ Block Colour Options
+
+		//more than one block
+		mojblocks-divider
 
 		//Accordion Block
 		mojblocks-accordion-section-title

--- a/assets/scss/page-colours.scss
+++ b/assets/scss/page-colours.scss
@@ -103,14 +103,12 @@ $brandings: (
     mojblocks-highlights-list-bg: $colour_gold_tint,
     mojblocks-highlights-list-title: $colour_charcoal_black,
     mojblocks-highlights-list-text: $colour_charcoal_black,
-    mojblocks-highlights-list-divider: $colour_earth_blue,
     mojblocks-reveal-title: $colour_sapphire_blue,
     mojblocks-reveal-title-hover: $colour_earth_blue,
     mojblocks-reveal-title-focus: $colour_earth_blue,
     mojblocks-reveal-title-focus-bg: $colour_gold_tint,
     mojblocks-reveal-title-focus-shadow: $colour_gold,
     mojblocks-staggered-box-bg: $colour_gold_tint,
-    mojblocks-staggered-box-divider: $colour_earth_blue,
     mojblocks-staggered-box-title: $colour_charcoal_black,
     mojblocks-staggered-box-text: $colour_charcoal_black,
     mojblocks-staggered-box-btn-border: $colour_earth_blue,
@@ -181,14 +179,12 @@ $brandings: (
     mojblocks-highlights-list-bg: $colour_turquoise_tint,
     mojblocks-highlights-list-title: $colour_charcoal_black,
     mojblocks-highlights-list-text: $colour_charcoal_black,
-    mojblocks-highlights-list-divider: $colour_neptune_blue,
     mojblocks-reveal-title: $colour_lagoon_blue,
     mojblocks-reveal-title-hover: $colour_deep_sea_blue,
     mojblocks-reveal-title-focus: $colour_deep_sea_blue,
     mojblocks-reveal-title-focus-bg: $colour_turquoise_tint,
     mojblocks-reveal-title-focus-shadow: $colour_turquoise,
     mojblocks-staggered-box-bg: $colour_turquoise_tint,
-    mojblocks-staggered-box-divider: $colour_neptune_blue,
     mojblocks-staggered-box-title: $colour_charcoal_black,
     mojblocks-staggered-box-text: $colour_charcoal_black,
     mojblocks-staggered-box-btn-border: $colour_lagoon_blue,
@@ -261,14 +257,12 @@ $brandings: (
     mojblocks-highlights-list-bg: $colour_uranus_teal,
     mojblocks-highlights-list-title: $colour_sunflower_yellow,
     mojblocks-highlights-list-text: govuk-colour("white"),
-    mojblocks-highlights-list-divider: $colour_sunflower_yellow,
     mojblocks-reveal-title: $colour_southsea_blue,
     mojblocks-reveal-title-hover: $colour_marine_blue,
     mojblocks-reveal-title-focus: $colour_charcoal_black,
     mojblocks-reveal-title-focus-bg: $colour_sunflower_yellow,
     mojblocks-reveal-title-focus-shadow: $colour_charcoal_black,
     mojblocks-staggered-box-bg: $colour_metal_grey,
-    mojblocks-staggered-box-divider: $colour_sunflower_yellow,
     mojblocks-staggered-box-title: govuk-colour("white"),
     mojblocks-staggered-box-text: govuk-colour("white"),
     mojblocks-staggered-box-btn-border: $colour_sunflower_yellow,
@@ -342,14 +336,12 @@ $brandings: (
     mojblocks-highlights-list-bg: $colour_flame_orange_tint,
     mojblocks-highlights-list-title: $colour_charcoal_black,
     mojblocks-highlights-list-text: $colour_charcoal_black,
-    mojblocks-highlights-list-divider: $colour_flame_orange,
     mojblocks-reveal-title: $colour_purple,
     mojblocks-reveal-title-hover: $colour_indigo,
     mojblocks-reveal-title-focus: $colour_indigo,
     mojblocks-reveal-title-focus-bg: $colour_flame_orange_tint,
     mojblocks-reveal-title-focus-shadow: $colour_flame_orange,
     mojblocks-staggered-box-bg: $colour_flame_orange_tint,
-    mojblocks-staggered-box-divider: $colour_flame_orange,
     mojblocks-staggered-box-title: $colour_charcoal_black,
     mojblocks-staggered-box-text: $colour_charcoal_black,
     mojblocks-staggered-box-btn-border: $colour_flame_orange,
@@ -422,14 +414,12 @@ $brandings: (
     mojblocks-highlights-list-bg: $colour_magenta_tint,
     mojblocks-highlights-list-title: $colour_charcoal_black,
     mojblocks-highlights-list-text: $colour_charcoal_black,
-    mojblocks-highlights-list-divider: $colour_magenta,
     mojblocks-reveal-title: $colour_magenta,
     mojblocks-reveal-title-hover: $colour_indigo,
     mojblocks-reveal-title-focus: $colour_indigo,
     mojblocks-reveal-title-focus-bg: $colour_magenta_tint,
     mojblocks-reveal-title-focus-shadow: $colour_magenta,
     mojblocks-staggered-box-bg: $colour_magenta_tint,
-    mojblocks-staggered-box-divider: $colour_magenta,
     mojblocks-staggered-box-title: $colour_charcoal_black,
     mojblocks-staggered-box-text: $colour_charcoal_black,
     mojblocks-staggered-box-btn-border: $colour_magenta,
@@ -553,7 +543,7 @@ $brandings: (
     mojblocks-highlights-list-bg
     mojblocks-highlights-list-title
     mojblocks-highlights-list-text
-    mojblocks-highlights-list-divider
+      (also uses mojblocks-divider)
 
     mojblocks-reveal-title
     mojblocks-reveal-title-hover
@@ -563,7 +553,6 @@ $brandings: (
 
     //Staggered Box
     mojblocks-staggered-box-bg
-    mojblocks-staggered-box-divider
     mojblocks-staggered-box-title
     mojblocks-staggered-box-text
     mojblocks-staggered-box-btn-border
@@ -575,6 +564,7 @@ $brandings: (
     mojblocks-staggered-box-btn-focus-border
     mojblocks-staggered-box-btn-focus-bg
     mojblocks-staggered-box-btn-focus-text
+      (also uses mojblocks-divider)
 */
 
 

--- a/assets/scss/page-colours.scss
+++ b/assets/scss/page-colours.scss
@@ -95,23 +95,9 @@ $brandings: (
     mojblocks-accordion-section-title-focus: $colour_earth_blue,
     mojblocks-accordion-section-title-focus-bg: $colour_gold_tint,
     mojblocks-accordion-section-title-focus-shadow: $colour_gold,
-    mojblocks-banner-btn-bg: $colour_sapphire_blue,
-    mojblocks-banner-btn-text: govuk-colour("white"),
-    mojblocks-banner-btn-hover-bg: $colour_earth_blue,
-    mojblocks-banner-btn-hover-text: govuk-colour("white"),
-    mojblocks-banner-btn-focus-bg: $colour_earth_blue,
-    mojblocks-banner-btn-focus-text: govuk-colour("white"),
-    mojblocks-banner-btn-focus-outline: $colour_gold,
     mojblocks-cta-bg: $colour_gold_tint,
     mojblocks-cta-title: $colour_charcoal_black,
     mojblocks-cta-text: $colour_charcoal_black,
-    mojblocks-cta-btn-bg: $colour_sapphire_blue,
-    mojblocks-cta-btn-text: govuk-colour("white"),
-    mojblocks-cta-btn-hover-bg: $colour_earth_blue,
-    mojblocks-cta-btn-hover-text: govuk-colour("white"),
-    mojblocks-cta-btn-focus-bg: $colour_earth_blue,
-    mojblocks-cta-btn-focus-text: govuk-colour("white"),
-    mojblocks-cta-btn-focus-outline: $colour_gold,
     mojblocks-hero-bg: $colour_gold_tint,
     mojblocks-highlights-list-bg: $colour_gold_tint,
     mojblocks-highlights-list-title: $colour_charcoal_black,
@@ -186,23 +172,9 @@ $brandings: (
     mojblocks-accordion-section-title-focus: $colour_deep_sea_blue,
     mojblocks-accordion-section-title-focus-bg: $colour_turquoise_tint,
     mojblocks-accordion-section-title-focus-shadow: $colour_turquoise,
-    mojblocks-banner-btn-bg: $colour_lagoon_blue,
-    mojblocks-banner-btn-text: govuk-colour("white"),
-    mojblocks-banner-btn-hover-bg: $colour_deep_sea_blue,
-    mojblocks-banner-btn-hover-text: govuk-colour("white"),
-    mojblocks-banner-btn-focus-bg: $colour_deep_sea_blue,
-    mojblocks-banner-btn-focus-text: govuk-colour("white"),
-    mojblocks-banner-btn-focus-outline: $colour_turquoise,
     mojblocks-cta-bg: $colour_turquoise_tint,
     mojblocks-cta-title: $colour_charcoal_black,
     mojblocks-cta-text: $colour_charcoal_black,
-    mojblocks-cta-btn-bg: $colour_lagoon_blue,
-    mojblocks-cta-btn-text: govuk-colour("white"),
-    mojblocks-cta-btn-hover-bg: $colour_deep_sea_blue,
-    mojblocks-cta-btn-hover-text: govuk-colour("white"),
-    mojblocks-cta-btn-focus-bg: $colour_deep_sea_blue,
-    mojblocks-cta-btn-focus-text: govuk-colour("white"),
-    mojblocks-cta-btn-focus-outline: $colour_turquoise,
     mojblocks-hero-bg: $colour_turquoise_tint,
     mojblocks-highlights-list-bg: $colour_turquoise_tint,
     mojblocks-highlights-list-title: $colour_charcoal_black,
@@ -279,23 +251,9 @@ $brandings: (
     mojblocks-accordion-section-title-focus-shadow: $colour_charcoal_black,
     mojblocks-accordion-controls: $colour_southsea_blue,
     mojblocks-accordion-controls-hover: $colour_marine_blue,
-    mojblocks-banner-btn-bg: $colour_sunflower_yellow,
-    mojblocks-banner-btn-text: $colour_charcoal_black,
-    mojblocks-banner-btn-hover-bg: $colour_charcoal_black,
-    mojblocks-banner-btn-hover-text: govuk-colour("white"),
-    mojblocks-banner-btn-focus-bg: $colour_charcoal_black,
-    mojblocks-banner-btn-focus-text: govuk-colour("white"),
-    mojblocks-banner-btn-focus-outline: $colour_sunflower_yellow,
     mojblocks-cta-bg: $colour_uranus_teal,
     mojblocks-cta-title: $colour_sunflower_yellow,
     mojblocks-cta-text: govuk-colour("white"),
-    mojblocks-cta-btn-bg: $colour_sunflower_yellow,
-    mojblocks-cta-btn-text: $colour_charcoal_black,
-    mojblocks-cta-btn-hover-bg: $colour_charcoal_black,
-    mojblocks-cta-btn-hover-text: govuk-colour("white"),
-    mojblocks-cta-btn-focus-bg: $colour_charcoal_black,
-    mojblocks-cta-btn-focus-text: govuk-colour("white"),
-    mojblocks-cta-btn-focus-outline: $colour_sunflower_yellow,
     mojblocks-hero-bg: $colour_uranus_teal_tint,
     mojblocks-highlights-list-bg: $colour_uranus_teal,
     mojblocks-highlights-list-title: $colour_sunflower_yellow,
@@ -373,23 +331,9 @@ $brandings: (
     mojblocks-accordion-section-title-focus-shadow: $colour_flame_orange,
     mojblocks-accordion-controls: $colour_purple,
     mojblocks-accordion-controls-hover: $colour_indigo,
-    mojblocks-banner-btn-bg: $colour_purple,
-    mojblocks-banner-btn-text: govuk-colour("white"),
-    mojblocks-banner-btn-hover-bg: $colour_indigo,
-    mojblocks-banner-btn-hover-text: govuk-colour("white"),
-    mojblocks-banner-btn-focus-bg: $colour_indigo,
-    mojblocks-banner-btn-focus-text: govuk-colour("white"),
-    mojblocks-banner-btn-focus-outline: $colour_flame_orange,
     mojblocks-cta-bg: $colour_flame_orange_tint,
     mojblocks-cta-title: $colour_charcoal_black,
     mojblocks-cta-text: $colour_charcoal_black,
-    mojblocks-cta-btn-bg: $colour_purple,
-    mojblocks-cta-btn-text: govuk-colour("white"),
-    mojblocks-cta-btn-hover-bg: $colour_indigo,
-    mojblocks-cta-btn-hover-text: govuk-colour("white"),
-    mojblocks-cta-btn-focus-bg: $colour_indigo,
-    mojblocks-cta-btn-focus-text: govuk-colour("white"),
-    mojblocks-cta-btn-focus-outline: $colour_flame_orange,
     mojblocks-hero-bg: $colour_flame_orange_tint,
     mojblocks-highlights-list-bg: $colour_flame_orange_tint,
     mojblocks-highlights-list-title: $colour_charcoal_black,
@@ -466,23 +410,9 @@ $brandings: (
     mojblocks-accordion-section-title-focus-shadow: $colour_magenta,
     mojblocks-accordion-controls: $colour_magenta,
     mojblocks-accordion-controls-hover: $colour_indigo,
-    mojblocks-banner-btn-bg: $colour_magenta,
-    mojblocks-banner-btn-text: govuk-colour("white"),
-    mojblocks-banner-btn-hover-bg: $colour_indigo,
-    mojblocks-banner-btn-hover-text: govuk-colour("white"),
-    mojblocks-banner-btn-focus-bg: $colour_indigo,
-    mojblocks-banner-btn-focus-text: govuk-colour("white"),
-    mojblocks-banner-btn-focus-outline: $colour_magenta,
     mojblocks-cta-bg: $colour_magenta_tint,
     mojblocks-cta-title: $colour_charcoal_black,
     mojblocks-cta-text: $colour_charcoal_black,
-    mojblocks-cta-btn-bg: $colour_magenta,
-    mojblocks-cta-btn-text: govuk-colour("white"),
-    mojblocks-cta-btn-hover-bg: $colour_indigo,
-    mojblocks-cta-btn-hover-text: govuk-colour("white"),
-    mojblocks-cta-btn-focus-bg: $colour_indigo,
-    mojblocks-cta-btn-focus-text: govuk-colour("white"),
-    mojblocks-cta-btn-focus-outline: $colour_magenta,
     mojblocks-hero-bg: $colour_magenta_tint,
     mojblocks-highlights-list-bg: $colour_magenta_tint,
     mojblocks-highlights-list-title: $colour_charcoal_black,
@@ -602,24 +532,11 @@ $brandings: (
     mojblocks-accordion-controls-hover
 
     //Banner Block
-    mojblocks-banner-btn-bg
-    mojblocks-banner-btn-text
-    mojblocks-banner-btn-hover-bg
-    mojblocks-banner-btn-hover-text
-    mojblocks-banner-btn-focus-bg
-    mojblocks-banner-btn-focus-text
-    mojblocks-banner-btn-focus-outline
 
     //CTA Block
     mojblocks-cta-bg
     mojblocks-cta-title
     mojblocks-cta-text
-    mojblocks-cta-btn-bg
-    mojblocks-cta-btn-text
-    mojblocks-cta-btn-hover-bg
-    mojblocks-cta-btn-hover-text
-    mojblocks-cta-btn-focus-bg
-    mojblocks-cta-btn-focus-text
 
     //Hero Block
     mojblocks-hero-bg


### PR DESCRIPTION
- removed the block-specific button colours.
- where already used, swapped these for the standard button colours (identical in all instances).
- removed the block-specific divider bar colours.
- replaced with a new common divider colour.
- added two new divider classes (for future use) with the styling to add a divider to any element.
  - one for "shaded" areas where the colour is the same as staggered box and the highlights blocks.
  - another for non-shaded areas where the bar tracks the colour of the text, as in the featured news block.
- fixed syntax error - stray comma on line 240