### PR TITLE
Fixed ODF icon bug

### DIFF
--- a/assets/scss/documents.scss
+++ b/assets/scss/documents.scss
@@ -15,10 +15,18 @@
       max-height: 264px;
     }
   }
-  &__icon svg {
-    height:1.2em;
-    position:relative;
-    top:3px;
-    padding-right:0.5em;
+  &__icon {
+    svg,img {
+      position:relative;
+      top:3px;
+      padding-right:0.5em;
+    }
+    svg {
+      height:1.2em;
+    }
+    img {
+      height:1em;
+      width: auto;
+    }
   }
 }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 2.14.1
+Version: 2.14.2
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
Added CSS for img as an icon (which happens when a non-standard filetype is used, such as ODT).  