### PR TITLE
wrapping menu items

### DIFF
--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -24,6 +24,12 @@
   .hale-header__logotype-text--custom {
     padding-left: 0.5em;
   }
+
+  //overrides the govuk nowrap and centres text for the longer menus found on hale
+  &.hale-header .govuk-header__navigation li a {
+    white-space: normal;
+    text-align: center;
+  }
 }
 
 .hale-header {

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 2.17.0
+Version: 2.17.1
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
overrides the govuk nowrap and centres text for the longer menus found on hale