### PR TITLE
apply govuk font sizes

### DIFF
--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -55,8 +55,6 @@
   .hale-heading-s {
     @include govuk-font(24);
     font-weight:700;
-    line-height: 145%;
-
   }
 
   h1 {
@@ -96,7 +94,6 @@
 
   p {
     @include govuk-font(19);
-    line-height: 155%;
   }
 
 
@@ -108,6 +105,5 @@
 
   .intro, .intro p {
     @include govuk-font(24);
-    line-height: 150%;
   }
 }

--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -9,7 +9,7 @@
     font-size: 4.25rem;
     line-height: 120%;
 
-    @include mq($from: desktop) {
+    @include govuk-media-query($from: tablet) {
       font-size: 76px;
       font-size: 4.75rem;
     }
@@ -21,7 +21,7 @@
     font-size: 3.125rem;
     line-height: 120%;
 
-    @include mq($from: desktop) {
+    @include govuk-media-query($from: tablet) {
       font-size: 56px;
       font-size: 3.5rem;
     }
@@ -33,7 +33,7 @@
     font-size: 2.375rem;
     line-height: 120%;
 
-    @include mq($from: desktop) {
+    @include govuk-media-query($from: tablet) {
       font-size: 42px;
       font-size: 2.625rem;
     }
@@ -45,7 +45,7 @@
     font-size: 1.75rem;
     line-height: 130%;
 
-    @include mq($from: desktop) {
+    @include govuk-media-query($from: tablet) {
       font-size: 32px;
       font-size: 2.0rem;
     }
@@ -53,14 +53,10 @@
 
   //Normally used for H4
   .hale-heading-s {
-    font-size: 22px;
-    font-size: 1.375rem;
+    @include govuk-font(24);
+    font-weight:700;
     line-height: 145%;
 
-    @include mq($from: desktop) {
-      font-size: 24px;
-      font-size: 1.5rem;
-    }
   }
 
   h1 {
@@ -99,14 +95,8 @@
 
 
   p {
-    font-size: 16px;
-    font-size: 1rem;
+    @include govuk-font(19);
     line-height: 155%;
-
-    @include mq($from: desktop) {
-      font-size: 18px;
-      font-size: 1.125rem;
-    }
   }
 
 
@@ -117,13 +107,7 @@
   }
 
   .intro, .intro p {
-    font-size: 22px;
-    font-size: 1.375rem;
+    @include govuk-font(24);
     line-height: 150%;
-
-    @include mq($from: desktop) {
-      font-size: 24px;
-      font-size: 1.5rem;
-    }
   }
 }

--- a/assets/scss/news.scss
+++ b/assets/scss/news.scss
@@ -7,7 +7,6 @@
 
   .news-story-details {
     @include govuk-font(19);
-    line-height: 155%;
     font-weight: bold;
   }
 

--- a/assets/scss/news.scss
+++ b/assets/scss/news.scss
@@ -6,15 +6,9 @@
   }
 
   .news-story-details {
-    font-size: 16px;
-    font-size: 1rem;
+    @include govuk-font(19);
     line-height: 155%;
     font-weight: bold;
-
-    @include mq($from: desktop) {
-      font-size: 18px;
-      font-size: 1.125rem;
-    }
   }
 
 }
@@ -55,8 +49,7 @@
 .news-story-count {
   font-weight: bold;
   border-bottom: 1px solid $colour_concrete_grey;
-  font-size: 24px;
-  font-size: 1.5rem;
+  @include govuk-font(24);
   padding-bottom: 16px;
 }
 

--- a/assets/scss/pagination.scss
+++ b/assets/scss/pagination.scss
@@ -218,11 +218,7 @@
       padding-left:30px;
 
       .gem-c-pagination__link-text {
-        font-size:1.375rem;
-
-        @include govuk-media-query($from: tablet) {
-          font-size:1.5rem;
-        }
+        @include govuk-font(24);
       }
     }
     .gem-c-pagination__link-label {

--- a/assets/scss/secondary-top-nav.scss
+++ b/assets/scss/secondary-top-nav.scss
@@ -27,13 +27,7 @@
       color: govuk-colour("black");
       text-decoration: none;
 
-      font-size: 16px;
-      font-size: 1rem;
-
-      @include mq($from: desktop) {
-        font-size: 18px;
-        font-size: 1.125rem;
-      }
+      @include govuk-font(19);
 
       &:hover {
         text-decoration: underline;


### PR DESCRIPTION
Make the breakpoint for larger font sizes tablet so headings are consistent with body text.  
Use GDS font styling for body text and smaller headings - where size matches, using 19px for previous 18px.  
