### PR TITLE
Disable archive pages (except news)

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -422,3 +422,9 @@ require get_template_directory() . '/inc/image-management.php';
  * Manage uploads
  */
 require get_template_directory() . '/inc/uploads.php';
+
+/**
+ * Disable archives 
+ */
+require get_template_directory() . '/inc/disable-archives.php';
+

--- a/inc/disable-archives.php
+++ b/inc/disable-archives.php
@@ -1,0 +1,26 @@
+<?php
+
+/* 
+ * Disable archives pages 
+ * 
+ * By default archive pages load in WP. These pages are currently 
+ * not designed or styled or used, but are getting picked up
+ * by search engines. This disables archive pages from loading
+ * with the exception of those specified below.
+ *
+*/
+
+add_action('template_redirect', 'hale_disable_archives_function');
+
+function hale_disable_archives_function()
+{
+    // Allow specific archives to display
+    $post_types = ['news'];
+
+  if ( (is_archive() && !is_post_type_archive( $post_types )) )
+  {
+      global $wp_query;
+      $wp_query->set_404();
+      status_header(404);
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 2.18.0
+Version: 2.19.0
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
Archive pages load by default even if they are not used. We don't want
these pages loading and being picked up by search engines,
until we have a use for them and have them styled.