### PR TITLE
Modify archive 404 restriction

### DIFF
--- a/inc/disable-archives.php
+++ b/inc/disable-archives.php
@@ -14,10 +14,10 @@ add_action('template_redirect', 'hale_disable_archives_function');
 
 function hale_disable_archives_function()
 {
-    // Allow specific archives to display
-    $post_types = ['news'];
 
-  if ( (is_archive() && !is_post_type_archive( $post_types )) )
+  // Currently only apply to specific archive pages,
+  // as others are being used on other sites
+  if ((is_archive() && is_tax('page_category')))
   {
       global $wp_query;
       $wp_query->set_404();

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 2.19.0
+Version: 2.19.1
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
VC uses some specific archive pages that we do not want to block. This
commit allows those pages while still blocking the specific 'page_cat'
archive.