### PR TITLE
Colour code rationalization

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -233,12 +233,13 @@ function hale_scripts() {
 //    wp_enqueue_style('hale-page-colours', hale_mix_asset('/css/page-colours.min.css'));
     if (!$browser_is_IE) wp_enqueue_style('hale-custom-branding', hale_mix_asset('/css/custom-branding.min.css'));
 
+    $t=time();
     if (is_customize_preview()) {
-        $css_file_name = "/temp-colours.css";
-        $css_file_name_IE = "/temp-colours-ie.css";
+        $css_file_name = "/temp-colours.css?t=$t";
+        $css_file_name_IE = "/temp-colours-ie.css?t=$t";
     } else {
-        $css_file_name = "/custom-colours.css";
-        $css_file_name_IE = "/custom-colours-ie.css";
+        $css_file_name = "/custom-colours.css?t=$t";
+        $css_file_name_IE = "/custom-colours-ie.css?t=$t";
     }
 
 

--- a/inc/colour-branding.php
+++ b/inc/colour-branding.php
@@ -28,6 +28,22 @@ function hale_generate_custom_colours() {
 	}
 
 	if ($upload_file_path_exists) {
+
+		//Create colour array with values from get_theme_mod for use in following for loops
+		$colour_value = array();
+		if ($custom_colours_set) {
+			for($i=0;$i<count($colour_array);$i++) {
+				$colour_id = hale_get_colour_id($colour_array[$i]);
+				$colour_default = hale_get_colour_default($colour_array[$i]);
+				$colour_options = hale_get_colour_options($colour_array[$i]);
+				$colour_value[$i] = array(
+										"id"=>$colour_id,
+										"value"=>get_theme_mod($colour_id,$colour_default),
+										"options"=>$colour_options
+									);
+			}
+		}
+
 		if ($jason) { // JSON file
 			$css = ":root {\n";
 			for($i=0;$i<count($colour_array);$i++) {
@@ -41,7 +57,7 @@ function hale_generate_custom_colours() {
 			for($i=0;$i<count($colour_array);$i++) {
 				$colour_id = hale_get_colour_id($colour_array[$i]);
 				$colour_default = hale_get_colour_default($colour_array[$i]);
-				$theme_mod = get_theme_mod($colour_id,$colour_default);
+				$theme_mod = $colour_value[$i]["value"];
 				if (!empty($theme_mod) ) {
 					$css .= "\t--$colour_id:$theme_mod;\n";
 				} else {
@@ -91,6 +107,7 @@ function hale_generate_custom_colours() {
 		//Copy the main CSS file so it can be changed into an IE-friendly file
 		copy($main_css_file,$upload_file_path."/temp-colours-ie.css") or die("That didn't work");
 		$css = file_get_contents($upload_file_path."/temp-colours-ie.css") or die("unable to get file contents");
+
 		for($i=0;$i<count($colour_array);$i++) {
 			$colour_id = hale_get_colour_id($colour_array[$i]);
 			$colour_default = hale_get_colour_default($colour_array[$i]);
@@ -98,7 +115,7 @@ function hale_generate_custom_colours() {
 			if ($jason) { //JSON file uploaded
 				$colour_to_use = $jason[$colour_id];
 			} elseif ($custom_colours_set) { //custom colours set
-				$colour_to_use = get_theme_mod($colour_id,$colour_default);
+				$colour_to_use = $colour_value[$i]["value"];
 			} else { //GDS colours
 				$colour_bar_colour = get_theme_mod('colour_bar','#1D70B8');
 				if ($colour_options == "brand-colour") $colour_default = $colour_bar_colour;

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -456,6 +456,15 @@ function hale_customize_register( $wp_customize ) {
 			)
 		);
 
+		$show_colours = function () use ($wp_customize) {
+			return (
+				(
+					$wp_customize->get_setting('gds_style_tickbox')->value() == 0
+					&&
+					!$wp_customize->get_setting('customizer_setting_json')->value()
+				)
+			);
+		};
 		$colour_array = hale_get_colours();
 		for ($i = 0; $i < count($colour_array); $i++) {
 			$colour_id = hale_get_colour_id($colour_array[$i]);
@@ -478,13 +487,7 @@ function hale_customize_register( $wp_customize ) {
 					'description' => esc_html__($colour_hint, 'hale'),
 					'section' => 'colors',
 					'type' => 'text',
-					'active_callback' => function () use ($wp_customize) {
-						return (
-						($wp_customize->get_setting('gds_style_tickbox')->value() == 0
-							&&
-							!$wp_customize->get_setting('customizer_setting_json')->value())
-						);
-					},
+					'active_callback' => $show_colours,
 				)
 			);
 		}


### PR DESCRIPTION
- Added cache-buster parameter to CSS file call
- Reduced repetition of call to `get_theme_mod`
- Moved identical active callback checks to outside of for loop