### PR TITLE
Table styling

### DIFF
--- a/assets/scss/core-wp-blocks-overrides.scss
+++ b/assets/scss/core-wp-blocks-overrides.scss
@@ -1,0 +1,23 @@
+/***
+
+Overrides core block styling so GDS styling can take effect
+
+***/
+
+//Table borders
+//Only adjust is-style-regular
+//revert settings which override GDS
+.wp-block-table.is-style-regular {
+	td, th {
+		border: unset;
+	}
+	thead {
+		border-bottom: unset;
+	}
+	tfoot {
+		border-top: unset;
+	}
+	figcaption {
+		text-align: unset;
+	}
+}

--- a/assets/scss/gds-design-system-settings.scss
+++ b/assets/scss/gds-design-system-settings.scss
@@ -1,4 +1,7 @@
 $govuk-font-family: 'PT Sans', sans-serif;
+
+//removes wordpress styling for core blocks
+@import 'core-wp-blocks-overrides';
 @import "node_modules/govuk-frontend/govuk/all";
 @import url(https://fonts.googleapis.com/css2?family=PT+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap);
 
@@ -81,4 +84,49 @@ $govuk-font-family: 'PT Sans', sans-serif;
 }
 .hale-search-results__last-updated-date{
   color: $govuk-secondary-text-colour;
+}
+
+/*--------------------------------------------------------------
+## GDS Tables
+--------------------------------------------------------------*/
+.wp-block-table.is-style-regular {
+  table {
+    @extend .govuk-table;
+
+    thead {
+      @extend .govuk-table__head !optional;
+    }
+
+    tbody {
+      @extend .govuk-table__body !optional;
+    }
+
+    tr {
+      @extend .govuk-table__row !optional;
+    }
+
+    th {
+      @extend .govuk-table__header;
+    }
+
+    td {
+      @extend .govuk-table__cell;
+    }
+
+    // WordPress default core block puts tables in a figure and uses a figcaption, so we must
+    // style these as needed here, including overriding the margins which put too much spacing
+    // betwixt them.
+
+    margin-bottom:10px;
+
+    + figcaption {
+      @extend .govuk-body-s;
+
+      margin-bottom:20px;
+
+      @include govuk-media-query($from: desktop) {
+        margin-bottom:30px;
+      }
+    }
+  }
 }

--- a/inc/restrict-blocks.php
+++ b/inc/restrict-blocks.php
@@ -25,6 +25,7 @@ function hale_allowed_block_types( $allowed_blocks ) {
             'core/embed',
             'core/button',
             'core/buttons',
+            'core/table',
             'mojblocks/accordion',
             'mojblocks/accordion-section',
             'mojblocks/banner',

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.2.3
+Version: 3.2.4
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
- Applied GDS styling to table block
  - As the WordPress block puts tables in a `<figure>` and adds a `<figcaption>` at the bottom, there are some new styles needed as well here, so it isn't just a matter of adding the classes.  
  - New styles done in a way sympathetic to the GDS styles.
- Unblocked the block