### PR TITLE
Amended CSS selector slightly

### DIFF
--- a/assets/scss/core-wp-blocks-overrides.scss
+++ b/assets/scss/core-wp-blocks-overrides.scss
@@ -5,9 +5,10 @@ Overrides core block styling so GDS styling can take effect
 ***/
 
 //Table borders
-//Only adjust is-style-regular
+//Only adjust default pattern (:not(.is-style-stripes))
+//Targetting .is-style-regular isn't robust as the class doesn't appear by default
 //revert settings which override GDS
-.wp-block-table.is-style-regular {
+.wp-block-table:not(.is-style-stripes) {
 	td, th {
 		border: unset;
 	}

--- a/assets/scss/gds-design-system-settings.scss
+++ b/assets/scss/gds-design-system-settings.scss
@@ -89,7 +89,7 @@ $govuk-font-family: 'PT Sans', sans-serif;
 /*--------------------------------------------------------------
 ## GDS Tables
 --------------------------------------------------------------*/
-.wp-block-table.is-style-regular {
+.wp-block-table:not(.is-style-stripes) {
   table {
     @extend .govuk-table;
 


### PR DESCRIPTION
The class `is-style-regular` was only added to tables where the editor had swapped over styles, so was not applied to all tables in the same way and was leading to unexpected styles and behaviour.  Changed the styling to omit the striped style rather than target the regular style.  