### PR TITLE
Fixed 'search button is a dot' issue

### DIFF
--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -375,6 +375,11 @@
         height: 27px;
         width: 27px;
       }
+
+      .hale-search__button-text {
+        //when in the header, the button text is SR only
+        @extend .govuk-visually-hidden;
+      }
     }
   }
 

--- a/searchform.php
+++ b/searchform.php
@@ -45,7 +45,7 @@ if ( ! isset( $GLOBALS['hale_search_form_counter'] ) ) {
 			<svg class="hale-icon hale-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 				<path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
 			</svg>
-			<span class="hale-search__button-text govuk-visually-hidden"><?php esc_html_e( 'Search', 'hale' ); ?></span>
+			<span class="hale-search__button-text"><?php esc_html_e( 'Search', 'hale' ); ?></span>
 		</button>
 	</form>
 </div>


### PR DESCRIPTION
Removed the class visually hidden for search button & re-added it in via an `@extend` in the CSS.