### PR TITLE
Wordpress 6.1 fixes

### DIFF
--- a/assets/scss/style-gutenburg.scss
+++ b/assets/scss/style-gutenburg.scss
@@ -47,3 +47,9 @@ $gutenberg-styles: true;
     }
   }
 }
+
+//Hides Add Template Button - Hopefully Wordpress will add an option to disable
+// https://wordpress.org/support/article/template-editor/
+.edit-post-post-template__form .components-button[aria-label="Add template"] {
+  display: none;
+}

--- a/functions.php
+++ b/functions.php
@@ -171,14 +171,9 @@ function wpse_remove_custom_colors() {
     // specifies the options (removed "normal")
     add_theme_support('editor-font-sizes', array(
         array(
-            'name' => 'Huge',
-            'size' => '50',
-            'slug' => 'huge'
-        ),
-        array(
-            'name' => 'Large',
-            'size' => '38',
-            'slug' => 'large'
+            'name' => 'Small',
+            'size' => '22',
+            'slug' => 'small'
         ),
         array(
             'name' => 'Medium',
@@ -186,9 +181,14 @@ function wpse_remove_custom_colors() {
             'slug' => 'medium'
         ),
         array(
-            'name' => 'Small',
-            'size' => '22',
-            'slug' => 'small'
+            'name' => 'Large',
+            'size' => '38',
+            'slug' => 'large'
+        ),
+        array(
+            'name' => 'Huge',
+            'size' => '50',
+            'slug' => 'huge'
         )
     ) );
 }

--- a/functions.php
+++ b/functions.php
@@ -528,3 +528,14 @@ function hale_manage_page_templates($post_templates,  $theme, $post, $post_type)
 }
 
 add_filter( 'theme_templates', 'hale_manage_page_templates' , 10, 4);
+
+
+// Remove Yoast `SEO Manager` role
+if ( get_role('wpseo_manager') ) {
+    remove_role( 'wpseo_manager' );
+}
+
+// Remove Yoast `SEO Editor` role
+if ( get_role('wpseo_editor') ) {
+    remove_role( 'wpseo_editor' );
+}


### PR DESCRIPTION
Fixes Typography bug with font sizes shown incorrect 
Hides Custom Template Feature - This is done by CSS as there is no WP permission to disable this feature yet.
Removes Yoast user roles.