### PR TITLE
Mobile menu tweaks

### DIFF
--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -209,6 +209,10 @@
 	//remove GDS brand colour bar
 	.govuk-header__container {
 		border-bottom: none;
+
+		&:after {
+			height: 10px;
+		}
 	}
 
 	.govuk-header {
@@ -374,6 +378,10 @@
 					border-bottom-color: var(--header-link-hover-border);
 
 					@include hale-heading-link-underline-restrictor($colour: --header-bg);
+				}
+
+				&:after {
+					content: none; // removes little arrow from dropdown menu - Hale uses an icon
 				}
 			}
 			.govuk-header__navigation-list {

--- a/assets/scss/gds-design-system-settings.scss
+++ b/assets/scss/gds-design-system-settings.scss
@@ -65,10 +65,7 @@ $govuk-font-family: 'PT Sans', sans-serif;
 	}
 	&[aria-expanded="true"] {
 		&:after {
-			-webkit-clip-path: polygon(50% 0,0 100%,100% 100%);
-			clip-path: polygon(50% 0,0 100%,100% 100%);
-			border-width: 0 5px 8.66px;
-			border-bottom-color: inherit;
+			content:none;
 		}
 		+ .hale-header__search-wrap {
 			display:block;

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.7.6
+Version: 3.7.7
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
CSS changes:
- New CSS to remove the little arrow when mobile menu and mobile search are expanded
  - This is a cosmetic hangover from changes introduced with version 4.3.0 of the GDS Design System
![image](https://user-images.githubusercontent.com/32877315/226893890-a377df55-3db8-47f6-8c91-1e1d3af14886.png)

- Fixed the longstanding issue with mobile menu where the last item would be partially cut off.
  - It was still fully readable, but looked naff.
  - this issue did not affect Magistrates, as gov-styled sites with the coloured bar didn't have this issue.  
![image](https://user-images.githubusercontent.com/32877315/226893967-2019bf36-ad23-4978-901b-4b3c6ab13234.png)

(Images are from live Victims Commissioner site)

New Hale version: 3.7.7
