### PR TITLE
New editor style to add a tiny margin

### DIFF
--- a/assets/scss/custom-branding.scss
+++ b/assets/scss/custom-branding.scss
@@ -14,3 +14,6 @@
 .block-editor-inserter__menu-help-panel {
   @import 'brandings-mojblocks';
 }
+
+//Editor styles
+@import 'editor';

--- a/assets/scss/editor.scss
+++ b/assets/scss/editor.scss
@@ -1,0 +1,10 @@
+/**
+ * This is designed to only effect the backend editor.  
+ * Therefore all styles should be a child of class .edit-post-layout
+*/
+
+.edit-post-visual-editor {
+	.editor-styles-wrapper {
+		margin: 0 2rem;
+	}
+}

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.7.7
+Version: 3.7.8
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
Added a 2 rem margin to each side of the `editor-styles-wrapper` class.

New SCSS file for editor only styles like this, which is imported via the `custom-brandings.scss` file.

New Hale Version: 3.7.8