### PR TITLE
Removed letter case options from Hale

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.7.10
+Version: 3.7.11
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */

--- a/theme.json
+++ b/theme.json
@@ -10,6 +10,9 @@
         "link": false,
         "palette": []
       },
+      "typography": {
+        "textTransform": false
+      },
       "blocks": {
         "core/paragraph": {
           "typography": {


### PR DESCRIPTION
- set text transform to **false** in `theme.json`
```
"typography": {
    "textTransform": false
},
```
New Hale version number: 3.7.11