### PR TITLE
Added editor-only borders and amended padding

### DIFF
--- a/assets/scss/editor.scss
+++ b/assets/scss/editor.scss
@@ -7,4 +7,33 @@
 	.editor-styles-wrapper {
 		margin: 0 2rem;
 	}
+
+	/**
+	 * Editor overrides
+	 * These styles are overrides to make wordpress blocks easier to manage in the editor interface
+	*/
+
+	// Table block
+	.wp-block-table {
+		&:not(.is-style-stripes) td,
+		td {
+			// adding dashed borders to aid editors visulisation of the table
+			border: 1px #b1b4b6;
+			border-style: dashed;
+			border-bottom-style: solid;
+			// overriding the normal padding to ease reading with the new dashed borders
+			padding: 10px;
+
+			&:last-child {
+				// overriding the normal padding to ease reading with the new dashed borders
+				// also makes table looked more uniform in the editor
+				padding: 10px;
+			}
+		}
+		&.is-style-stripes td {
+			// top and bottom are not needed for striped design
+			border-top-style: none;
+			border-bottom-style: none;
+		}
+	}
 }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.7.11
+Version: 3.7.12
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
Style changes to backend tables:

For all tables
- all cells made equal width
- cell content centred

For striped tables
- new dashed vertical borders delimit the different columns (existing stripes delimit the cells)

For standard tables
- new dashed borders delimit the cells, keeping a solid bottom border as per the main design

New Hale Version: 3.7.12