### PR TITLE
Accessibility improvements

### DIFF
--- a/assets/scss/fontstyles/pt-sans.scss
+++ b/assets/scss/fontstyles/pt-sans.scss
@@ -57,19 +57,20 @@
     font-weight:700;
   }
 
-  h1 {
+  // only classless
+  h1:not([class]) {
     @extend .hale-heading-xl;
   }
 
-  h2 {
+  h2:not([class]) {
     @extend .hale-heading-l;
   }
 
-  h3 {
+  h3:not([class]) {
     @extend .hale-heading-m;
   }
 
-  h4 {
+  h4:not([class]) {
     @extend .hale-heading-s;
   }
 
@@ -92,7 +93,7 @@
   }
 
 
-  p {
+  p:not([class|="govuk"]) {
     @include govuk-font(19);
   }
 

--- a/assets/scss/footer.scss
+++ b/assets/scss/footer.scss
@@ -11,7 +11,7 @@
     display: block;
     line-height: 2;
 
-    @media (min-width: 48.0625em) {
+    @include govuk-media-query($from: desktop) {
       line-height: 1;
       margin-bottom: 30px;
     }
@@ -29,7 +29,7 @@
       column-count: 2;
     }
 
-    @media (min-width: 48.0625em) {
+    @include govuk-media-query($from: desktop) {
       line-height: 1;
       margin-bottom: 30px;
 

--- a/assets/scss/gds-design-system-settings.scss
+++ b/assets/scss/gds-design-system-settings.scss
@@ -54,12 +54,12 @@ $govuk-font-family: 'PT Sans', sans-serif;
 }
 .js-enabled .hale-header .hale-header__mobile-controls--search {
 	right: 60px;
-	@include govuk-media-query($from: tablet) {
+	@include govuk-media-query($from: desktop) {
 		display:none;
 	}
 	+ .hale-header__search-wrap {
 		display:none;
-		@include govuk-media-query($from: tablet) {
+		@include govuk-media-query($from: desktop) {
 			display:block;
 		}
 	}
@@ -70,7 +70,7 @@ $govuk-font-family: 'PT Sans', sans-serif;
 		+ .hale-header__search-wrap {
 			display:block;
 			margin-top: 2em;
-			@include govuk-media-query($from: tablet) {
+			@include govuk-media-query($from: desktop) {
 				margin-top: 0;
 			}
 		}

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -272,14 +272,17 @@
     }
   }
 
-  .govuk-header__logo {
-    //make this a min-width to account for the longer header texts than "GOV.UK"
-    width: unset;
-    min-width: 33.33%;
+  &.hale-header--with-search .govuk-header__logo {
     @include govuk-media-query($from: desktop) {
       // space for search box
       max-width: calc(100% - 285px);
     }
+  }
+
+  .govuk-header__logo {
+    //make this a min-width to account for the longer header texts than "GOV.UK"
+    width: unset;
+    min-width: 33.33%;
 
     .govuk-header__link--homepage {
       display: inline-block;

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -276,6 +276,10 @@
     //make this a min-width to account for the longer header texts than "GOV.UK"
     width: unset;
     min-width: 33.33%;
+    @include govuk-media-query($from: desktop) {
+      // space for search box
+      max-width: calc(100% - 285px);
+    }
 
     .govuk-header__link--homepage {
       display: inline-block;
@@ -296,6 +300,7 @@
 
       .hale-header__logo--custom {
         float: left;
+        min-width: 43px;
       }
     }
   }
@@ -478,14 +483,9 @@
 .hale-header .hale-header__search-form {
   margin-right:66px;
   width: 100%;
-  @include govuk-media-query($from: tablet) {
-    //space for menu button
-    width: calc(15rem + 44px);
-    margin-left:auto;
-    position:relative;
-    top: -37px;
-  }
   @include govuk-media-query($from: desktop) {
+    width: 284px;
+    position:relative;
     top: 0;
     margin-left:auto;
     margin-right:0;

--- a/assets/scss/moj-blocks-general.scss
+++ b/assets/scss/moj-blocks-general.scss
@@ -1,7 +1,8 @@
 .hale-page {
   // Deals with the Hero and the highlight/shaded blocks (e.g. CTA, highlighted list)
-  // The shading for these have (need) widths of over 100vw which leads to poor horizontal
-  // This prevents this from being an issue (no content, just highlighting) by preventing horizontal scroll
+  // The shading for these have (need) widths of over 100vw which leads to undesirable horizontal scrolling
+  // No content is outside of the page area, just highlighting.
+  // This prevents this from being an issue by preventing horizontal scroll
   overflow-x: hidden;
 }
 

--- a/assets/scss/moj-blocks-general.scss
+++ b/assets/scss/moj-blocks-general.scss
@@ -1,3 +1,10 @@
+.hale-page {
+  // Deals with the Hero and the highlight/shaded blocks (e.g. CTA, highlighted list)
+  // The shading for these have (need) widths of over 100vw which leads to poor horizontal
+  // This prevents this from being an issue (no content, just highlighting) by preventing horizontal scroll
+  overflow-x: hidden;
+}
+
 .govuk-main-wrapper {
   p:not([class]), p[class=""] {
     //deals with any paragraphs that aren't classed - makes them GDS paragraphs

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,20 +61,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.6.tgz",
-      "integrity": "sha512-HPIyDa6n+HKw5dEuway3vVAhBboYCtREBMp+IWeseZy6TFtzn6MHkCH2KKYUOC/vKKwgSMHQW4htBOrmuRPXfw==",
+      "version": "7.22.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.8.tgz",
+      "integrity": "sha512-75+KxFB4CZqYRXjx4NlR4J7yGvKumBuZTmV4NV6v09dVXXkuYVYLT68N6HCzLvfJ+fWCxQsntNzKwwIXL4bHnw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.5",
+        "@babel/generator": "^7.22.7",
         "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-module-transforms": "^7.22.5",
         "@babel/helpers": "^7.22.6",
-        "@babel/parser": "^7.22.6",
+        "@babel/parser": "^7.22.7",
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.6",
+        "@babel/traverse": "^7.22.8",
         "@babel/types": "^7.22.5",
         "@nicolo-ribaudo/semver-v6": "^6.3.3",
         "convert-source-map": "^1.7.0",
@@ -91,9 +91,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
-      "integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.7.tgz",
+      "integrity": "sha512-p+jPjMG+SI8yvIaxGgeW24u7q9+5+TGpZh8/CuB7RhBKd7RCy8FayNEFNNKrNK/eUcY/4ExQqLmyrvBXKsIcwQ==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5",
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.6.tgz",
-      "integrity": "sha512-EIQu22vNkceq3LbjAq7knDf/UmtI2qbcNI8GRBlijez6TpQLvSodJPYfydQmNA5buwkxxxa/PVI44jjYZ+/cLw==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
+      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -847,9 +847,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.5.tgz",
-      "integrity": "sha512-gGOEvFzm3fWoyD5uZq7vVTD57pPJ3PczPUD/xCFGjzBpUosnklmXyKnGQbbbGs1NPNPskFex0j93yKbHt0cHyg==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.7.tgz",
+      "integrity": "sha512-7HmE7pk/Fmke45TODvxvkxRMV9RazV+ZZzhOL9AG8G29TLrr3jkjwF7uJfxZ30EoXpO+LJkq4oA8NjO2DTnEDg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.5",
@@ -1465,17 +1465,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.22.6.tgz",
-      "integrity": "sha512-+AGkst7Kqq3QUflKGkhWWMRb9vaKamoreNmYc+sjsIpOp+TsyU0exhp3RlwjQa/HdlKkPt3AMDwfg8Hpt9Vwqg==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.22.7.tgz",
+      "integrity": "sha512-o02xM7iY7mSPI+TvaYDH0aYl+lg3+KT7qrD705JlsB/GrZSNaYO/4i+aDFKPiJ7ubq3hgv8NNLCdyB5MFxT8mg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.22.5",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@nicolo-ribaudo/semver-v6": "^6.3.3",
-        "babel-plugin-polyfill-corejs2": "^0.4.3",
-        "babel-plugin-polyfill-corejs3": "^0.8.1",
-        "babel-plugin-polyfill-regenerator": "^0.5.0"
+        "babel-plugin-polyfill-corejs2": "^0.4.4",
+        "babel-plugin-polyfill-corejs3": "^0.8.2",
+        "babel-plugin-polyfill-regenerator": "^0.5.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.6.tgz",
-      "integrity": "sha512-IHr0AXHGk8oh8HYSs45Mxuv6iySUBwDTIzJSnXN7PURqHdxJVQlCoXmKJgyvSS9bcNf9NVRVE35z+LkCvGmi6w==",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.7.tgz",
+      "integrity": "sha512-1whfDtW+CzhETuzYXfcgZAh8/GFMeEbz0V5dVgya8YeJyCU6Y/P2Gnx4Qb3MylK68Zu9UiwUvbPMPTpFAOJ+sQ==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
@@ -1655,7 +1655,7 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.22.5",
-        "@babel/plugin-transform-async-generator-functions": "^7.22.5",
+        "@babel/plugin-transform-async-generator-functions": "^7.22.7",
         "@babel/plugin-transform-async-to-generator": "^7.22.5",
         "@babel/plugin-transform-block-scoped-functions": "^7.22.5",
         "@babel/plugin-transform-block-scoping": "^7.22.5",
@@ -1705,9 +1705,9 @@
         "@babel/preset-modules": "^0.1.5",
         "@babel/types": "^7.22.5",
         "@nicolo-ribaudo/semver-v6": "^6.3.3",
-        "babel-plugin-polyfill-corejs2": "^0.4.3",
-        "babel-plugin-polyfill-corejs3": "^0.8.1",
-        "babel-plugin-polyfill-regenerator": "^0.5.0",
+        "babel-plugin-polyfill-corejs2": "^0.4.4",
+        "babel-plugin-polyfill-corejs3": "^0.8.2",
+        "babel-plugin-polyfill-regenerator": "^0.5.1",
         "core-js-compat": "^3.31.0"
       },
       "engines": {
@@ -1766,18 +1766,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.6.tgz",
-      "integrity": "sha512-53CijMvKlLIDlOTrdWiHileRddlIiwUIyCKqYa7lYnnPldXCG5dUSN38uT0cA6i7rHWNKJLH0VU/Kxdr1GzB3w==",
+      "version": "7.22.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
+      "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.5",
+        "@babel/generator": "^7.22.7",
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.6",
+        "@babel/parser": "^7.22.7",
         "@babel/types": "^7.22.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -5034,9 +5034,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.6.0.tgz",
-      "integrity": "sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -7231,9 +7231,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
+      "integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
       "dev": true,
       "funding": [
         {

--- a/page-full-width.php
+++ b/page-full-width.php
@@ -45,7 +45,7 @@ while (have_posts()) :
 
          // Header loads if category not selected on page
                 if (empty($is_cat_page)) { ?>
-                 <h1 class="govuk-heading-l"><?php the_title(); ?></h1>
+                 <h1 class="govuk-heading-l hale-heading-xl"><?php the_title(); ?></h1>
              <?php
                 }
 

--- a/page.php
+++ b/page.php
@@ -52,7 +52,7 @@ while (have_posts()) :
 
          // Header loads if category not selected on page
                 if (empty($is_cat_page)) { ?>
-                 <h1 class="govuk-heading-l"><?php the_title(); ?></h1>
+                 <h1 class="govuk-heading-l hale-heading-xl"><?php the_title(); ?></h1>
              <?php
                 }
 

--- a/search.php
+++ b/search.php
@@ -19,10 +19,15 @@ get_header();
 		<header class="hale-search-header" style="">
       <h1 class="govuk-heading-l hale-heading-xl">
         Search Results
-        <p class="govuk-body-l">for
+        <p class="govuk-body-l">
           <?php 
             /* translators: %s: search term */
-            printf(get_search_query());
+            if (get_search_query() == "") {
+              printf("No search words entered");
+            } else {
+              printf("for ".get_search_query());
+            }
+
             $header_search = get_theme_mod( 'show_search', 'yes' );
           ?>
         </p>

--- a/search.php
+++ b/search.php
@@ -62,7 +62,7 @@ get_header();
 
               <h3 class="govuk-heading-m">
                 <a class="govuk-link" href="<?php the_permalink(); ?>">
-                  <?php the_title( ); ?>
+                  <?php echo strip_tags(get_the_title()); ?>
                 </a>
               </h2>
 

--- a/search.php
+++ b/search.php
@@ -17,9 +17,10 @@ get_header();
 
 	<div id="primary" class="govuk-grid-column-two-thirds">
 		<header class="hale-search-header" style="">
-      <h1 class="govuk-heading-l hale-heading-xl">
-        Search Results
-        <p class="govuk-body-l">
+      <h1 class="govuk-heading-l hale-heading-xl" style="line-height:0;">
+        <span class="govuk-heading-l hale-heading-xl govuk-!-margin-bottom-0">Search Results</span>
+        <br />
+        <span class="govuk-body-l">
           <?php 
             /* translators: %s: search term */
             if (get_search_query() == "") {
@@ -30,7 +31,7 @@ get_header();
 
             $header_search = get_theme_mod( 'show_search', 'yes' );
           ?>
-        </p>
+        </span>
       </h1>
       <?php get_search_form(); ?>
 		</header>

--- a/search.php
+++ b/search.php
@@ -17,15 +17,15 @@ get_header();
 
 	<div id="primary" class="govuk-grid-column-two-thirds">
 		<header class="hale-search-header" style="">
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-l hale-heading-xl">
         Search Results
-        <span class="govuk-caption-m">for 
+        <p class="govuk-body-l">for
           <?php 
             /* translators: %s: search term */
             printf(get_search_query());
             $header_search = get_theme_mod( 'show_search', 'yes' );
           ?>
-        </span>
+        </p>
       </h1>
       <?php get_search_form(); ?>
 		</header>

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.9.1
+Version: 3.9.2
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -13,7 +13,7 @@
 
 <section class="no-results not-found">
 	<header class="entry-header">
-		<h1 class="page-title"><?php esc_html_e( 'Nothing Found', 'hale' ); ?></h1>
+		<h2 class="govuk-heading-l"><?php esc_html_e( 'Nothing Found', 'hale' ); ?></h2>
 	</header><!-- .page-header -->
 
 	<div class="page-content">


### PR DESCRIPTION
Fixes various accessibility failings/observations as per Martin Glancy's comments:

### R14
Double H1 on search results page when none found
- Changed the second H1 to an H2.  
- Changed the class to a suitable class.
- Amended CSS as GDS heading class styling was being overridden.
- Added a few more classes elsewhere to prevent style changes by above change. 

### R13
Search box covers up banner text (page title/logo), also the search box breaks apart at some widths.
- Search box switches to mobile earlier (same as menu)
- Max-width styles introduced to stop search box from breaking up - this means that the site title might wrap a little earlier now.

### R06
Horizontal scrolling caused by earlier fix to highlighted fields
- Added a style to prevent horizontal scrolling, as there is no content outside of the visible area this is all that is needed.  

### R15
Search for term not clear
- Design decision, but I have increased contrast here to improve matters. 
- I did this by changing it from a `caption-m` to a `body-l`. 
- Rejig of HTML to get this to display as needed, especially as we want both lines to be within the H1.

### R16
Ghost links in search results
- This was caused by HTML in page titles, specifically links.  Whilst this is a content problem, to increase system robustness, I have stripped all HTML tags from the search result title.  

### R24
Blank searches return results
- Not a problem per se, but the search page just says "search results for", which isn't great. 
- I have added logic so if the search term is blank, it tells the user that no search term was entered.  
- Wording approved by Anna.

### Also
- Future proofed media queries in footer by making them use the GDS breakpoints.