### PR TITLE
Colour bug fix

### DIFF
--- a/assets/scss/brandings-mojblocks.scss
+++ b/assets/scss/brandings-mojblocks.scss
@@ -2,7 +2,7 @@
 
 //brandings for MOj Blocks
 
-*{
+html.hale-colours-variable {
 	//Accordion block
 	.govuk-accordion,
 	.js-enabled .govuk-accordion {

--- a/assets/scss/brandings-mojblocks.scss
+++ b/assets/scss/brandings-mojblocks.scss
@@ -11,31 +11,69 @@
 		}
 
 		&__controls {
-			.govuk-accordion__open-all {
+			.govuk-accordion__show-all {
 
-				color: var(--mojblocks-accordion-section-title);
+				color: var(--mojblocks-accordion-section-shew);
 
 				&:hover {
-					color: var(--mojblocks-accordion-section-title-hover);
+					color: var(--mojblocks-accordion-section-shew-hover);
 				}
 
 				&:focus {
-					color: var(--mojblocks-accordion-section-title-focus);
+					color: var(--mojblocks-accordion-section-shew-focus);
 					background-color: var(--mojblocks-accordion-section-title-focus-bg);
 					box-shadow: 0 -2px var(--mojblocks-accordion-section-title-focus-bg), 0 4px var(--mojblocks-accordion-section-title-focus-shadow);
+				}
+			}
+		}
+		&__section-button {
+			.govuk-accordion__section-heading-text-focus {
+				color: var(--mojblocks-accordion-section-title);
+			}
+			.govuk-accordion__section-toggle-text,
+			.govuk-accordion__section-toggle-focus {
+				color: var(--mojblocks-accordion-section-shew);
+
+				.govuk-accordion-nav__chevron {
+					color: var(--mojblocks-accordion-section-shew);
+				}
+			}
+		}
+		&__section-button:hover {
+			background-color: var(--mojblocks-accordion-section-item-hover-bg);
+
+			.govuk-accordion__section-heading-text-focus {
+				color: var(--mojblocks-accordion-section-title-hover);
+			}
+
+			.govuk-accordion__section-toggle-text,
+			.govuk-accordion__section-toggle-focus {
+				color: var(--mojblocks-accordion-section-shew-hover);
+
+				.govuk-accordion-nav__chevron {
+					color: var(--mojblocks-accordion-section-shew-hover);
+					background-color: var(--mojblocks-accordion-section-shew-hover);
 				}
 			}
 		}
 		&__section-button:focus {
 			.govuk-accordion__section-heading-text-focus,
 			.govuk-accordion__section-toggle-focus {
-				color: var(--mojblocks-accordion-section-title-focus);
 				background-color: var(--mojblocks-accordion-section-title-focus-bg);
 				box-shadow: 0 -2px var(--mojblocks-accordion-section-title-focus-bg), 0 4px var(--mojblocks-accordion-section-title-focus-shadow);
+			}
+			.govuk-accordion__section-heading-text-focus {
+				color: var(--mojblocks-accordion-section-title-focus);
+			}
+			.govuk-accordion__section-toggle-focus {
+				color: var(--mojblocks-accordion-section-shew-focus);
+				.govuk-accordion__section-toggle-text {
+					color: var(--mojblocks-accordion-section-shew-focus);
+				}
 
 				.govuk-accordion-nav__chevron {
-					color: var(--mojblocks-accordion-section-title-focus);
-					background-color: var(--mojblocks-accordion-section-title-focus);
+					color: var(--mojblocks-accordion-section-shew-focus);
+					background-color: var(--mojblocks-accordion-section-shew-focus);
 
 					&:after {
 						color: var(--mojblocks-accordion-section-title-focus-bg);

--- a/assets/scss/brandings-mojblocks.scss
+++ b/assets/scss/brandings-mojblocks.scss
@@ -168,14 +168,14 @@
 	.wp-block-button__link,
 	.govuk-button {
 		border:var(--button-border);
-		box-shadow: 0 1px 0 var(--button);
+		box-shadow: none;
 		color:var(--button-text);
 		background-color:var(--button);
 		&:hover {
 			background-color: var(--button-hover);
 			color: var(--button-hover-text);
-			box-shadow: 0 1px 0 var(--button-hover);
-			border-color: var(--link-focus);
+			box-shadow: none;
+			border-color: var(--button-hover-border);
 			svg {
 				fill: var(--button-hover-text);
 			}
@@ -187,11 +187,13 @@
 		&:focus {
 			background-color: var(--button-focus);
 			color: var(--button-focus-text);
+			border-color: var(--button-focus-outline);
 			box-shadow: 0 0 0 3px var(--button-focus-outline);
 		}
 		&:focus:not(:active):not(:hover) {
 			background-color: var(--button-focus);
 			color: var(--button-focus-text);
+			border-color: var(--button-focus-outline);
 			box-shadow: 0 0 0 3px var(--button-focus-outline);
 		}
 		svg {

--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -456,19 +456,20 @@
 			}
 		}
 	}
+	// some button styles are in brandings-mojblocks.scss
 	.mojblocks-button,
 	a.mojblocks-button,
 	.govuk-button:link,
 	.govuk-button {
 		border:var(--button-border);
-		box-shadow: 0 1px 0 var(--button);
+		box-shadow: none;
 		color:var(--button-text);
 		background-color:var(--button);
 		&:hover {
 			background-color: var(--button-hover);
 			color: var(--button-hover-text);
-			box-shadow: 0 1px 0 var(--button-hover);
-			border-color: var(--link-focus);
+			box-shadow: none;
+			border-color: var(--button-hover-border);
 			svg {
 				fill: var(--button-hover-text);
 			}
@@ -480,11 +481,13 @@
 		&:focus {
 			background-color: var(--button-focus);
 			color: var(--button-focus-text);
+			border-color: var(--button-focus-outline);
 			box-shadow: 0 0 0 3px var(--button-focus-outline);
 		}
 		&:focus:not(:active):not(:hover) {
 			background-color: var(--button-focus);
 			color: var(--button-focus-text);
+			border-color: var(--button-focus-outline);
 			box-shadow: 0 0 0 3px var(--button-focus-outline);
 		}
 		svg {

--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -42,7 +42,10 @@
 }
 
 
-*{
+/***
+* These styles are applied to all sites
+*/
+* {
 	//style WP button block as GDS button
 	.wp-block-button__link:not(.govuk-button) {
 		@extend .govuk-button;
@@ -51,37 +54,6 @@
 	//search page only style (affects search in header but not adversely so
 	.hale-search__input {
 		margin-bottom: 30px;
-	}
-
-	.news-story-category-link {
-		color: var(--tag-text);
-		background: var(--tag-bg);
-
-		&:focus {
-			color: var(--tag-focus-text);
-			background: var(--tag-focus-bg);
-			outline-color: var(--tag-focus-outline)
-		}
-		&:hover, &:active {
-			color: var(--tag-hover-text);
-			background: var(--tag-hover-bg);
-		}
-	}
-
-	.govuk-skip-link:focus {
-		outline-color: var(--header-link-focus-underline);
-		background-color: var(--header-link-focus-highlight);
-	}
-
-	//Cookie banner styling formerly here, but have been moved to new file - brandings-cookies.scss
-
-	//remove GDS brand colour bar
-	.govuk-header__container {
-		border-bottom: none;
-
-		&:after {
-			height: 10px;
-		}
 	}
 
 	.govuk-header {
@@ -456,6 +428,89 @@
 			}
 		}
 	}
+	.news-story-category-link {
+		color: var(--tag-text);
+		background: var(--tag-bg);
+
+		&:focus {
+			color: var(--tag-focus-text);
+			background: var(--tag-focus-bg);
+			outline-color: var(--tag-focus-outline)
+		}
+		&:hover, &:active {
+			color: var(--tag-hover-text);
+			background: var(--tag-hover-bg);
+		}
+	}
+
+	//link focus state
+	#primary a:not([class]),
+	#primary a[class="customize-unpreviewable"],
+	#primary a[class=""],
+	.hale-article-nav,
+	a.govuk-link,
+	.moj-pagination__link {
+		&:focus {
+			color: var(--link-focus);
+			background-color: var(--link-focus-background);
+			box-shadow: 0 -2px var(--link-focus-background), 0 4px var(--link-focus-shadow);
+			outline: 4px solid transparent;
+
+			.gem-c-pagination__link-label {
+				color: var(--link-focus);
+			}
+		}
+	}
+	.govuk-main-wrapper .govuk-link:link,
+	.govuk-main-wrapper a:link:not([class]),
+	.govuk-main-wrapper a[class="customize-unpreviewable"]:link, // for wordpress customizer
+	.gem-c-pagination__link:link {
+		color: var(--link);
+
+		&:hover:not(:focus) {
+			color: var(--link-hover);
+		}
+		&:focus {
+			color: var(--link-focus);
+		}
+	}
+
+	.govuk-main-wrapper .govuk-link:visited,
+	.govuk-main-wrapper a:visited:not([class]),
+	.gem-c-pagination__link:visited {
+
+		color: var(--link-visited);
+
+		&:hover:not(:focus) {
+			color: var(--link-hover);
+		}
+		&:focus {
+			color: var(--link-focus);
+		}
+	}
+}
+
+/***
+* These styles are only applied to sites which have not opted for GDS styles
+*/
+html.hale-colours-variable {
+
+	.govuk-skip-link:focus {
+		outline-color: var(--header-link-focus-underline);
+		background-color: var(--header-link-focus-highlight);
+	}
+
+	//Cookie banner styling formerly here, but have been moved to new file - brandings-cookies.scss
+
+	//remove GDS brand colour bar
+	.govuk-header__container {
+		border-bottom: none;
+
+		&:after {
+			height: 10px;
+		}
+	}
+
 	// some button styles are in brandings-mojblocks.scss
 	.mojblocks-button,
 	a.mojblocks-button,
@@ -507,34 +562,6 @@
 		}
 	}
 
-	.govuk-main-wrapper .govuk-link:link,
-	.govuk-main-wrapper a:link:not([class]),
-	.govuk-main-wrapper a[class="customize-unpreviewable"]:link, // for wordpress customizer
-	.gem-c-pagination__link:link {
-		color: var(--link);
-
-		&:hover:not(:focus) {
-			color: var(--link-hover);
-		}
-		&:focus {
-			color: var(--link-focus);
-		}
-	}
-
-	.govuk-main-wrapper .govuk-link:visited,
-	.govuk-main-wrapper a:visited:not([class]),
-	.gem-c-pagination__link:visited {
-
-		color: var(--link-visited);
-
-		&:hover:not(:focus) {
-			color: var(--link-hover);
-		}
-		&:focus {
-			color: var(--link-focus);
-		}
-	}
-
 	.govuk-breadcrumbs__link,
 	.govuk-back-link {
 		@extend .govuk-link;
@@ -552,24 +579,7 @@
 		}
 	}
 
-	//link focus state
-	#primary a:not([class]),
-	#primary a[class="customize-unpreviewable"],
-	#primary a[class=""],
-	.hale-article-nav,
-	a.govuk-link,
-	.moj-pagination__link {
-		&:focus {
-			color: var(--link-focus);
-			background-color: var(--link-focus-background);
-			box-shadow: 0 -2px var(--link-focus-background), 0 4px var(--link-focus-shadow);
-			outline: 4px solid transparent;
-
-			.gem-c-pagination__link-label {
-				color: var(--link-focus);
-			}
-		}
-	}
+	//link focus state (breadcrumbs)
 	a.govuk-breadcrumbs__link,
 	a.govuk-back-link {
 		&:focus {

--- a/assets/scss/hale-styles.scss
+++ b/assets/scss/hale-styles.scss
@@ -22,10 +22,6 @@
 	line-height:1.5;
 }
 
-.govuk-button {
-  border-radius: 4px;
-}
-
 .govuk-breadcrumbs {
   padding: 0.7em 0;
 }

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -499,8 +499,8 @@
     border-top-right-radius: 4px;
 
     +.govuk-button.hale-search__submit {
-      border-bottom-left-radius: 0;
-      border-top-left-radius: 0;
+      border-bottom-right-radius: 4px;
+      border-top-right-radius: 4px;
     }
     &:focus {
       outline-width: 3px;

--- a/header.php
+++ b/header.php
@@ -9,9 +9,15 @@
  * @version   1.0
  */
 
+	$custom_colours_set = ! get_theme_mod("gds_style_tickbox");
+	if (!$custom_colours_set) {
+		$style_class = "hale-colours-gds-standard";
+	} else {
+		$style_class = "hale-colours-variable";
+	}
 ?>
 <!DOCTYPE html>
-<html <?php language_attributes(); ?> class="hale-page">
+<html <?php language_attributes(); ?> class="hale-page <?php printf($style_class); ?>">
 <head>
 
 	<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/inc/colour-branding.php
+++ b/inc/colour-branding.php
@@ -86,29 +86,6 @@ function hale_generate_custom_colours() {
 				$colour_bar_style .= "}\n";
 				$css .= $colour_bar_style;
 			}
-			// Here we apply the GDS button styles which are different from non-GDS
-			// We remove rounded corners
-			// We add a box shadow for bottom
-			// We deal with their strange hover-focus combinations
-			$gov_button_style_override  = ".wp-block-button__link,";
-			$gov_button_style_override .= ".mojblocks-button,";
-			$gov_button_style_override .= ".govuk-button:not(.govuk-button--secondary) { \n\t";
-			$gov_button_style_override .= 	"border-radius:0!important;;\n\t";
-			$gov_button_style_override .= 	"box-shadow:0 2px 0 #002d18!important;\n";
-			$gov_button_style_override .= "}\n";
-			$gov_button_style_override .= ".wp-block-button__link:focus:not(:active):not(:hover),";
-			$gov_button_style_override .= ".mojblocks-button:focus:not(:active):not(:hover),";
-			$gov_button_style_override .= ".govuk-button:not(.govuk-button--secondary):focus:not(:active):not(:hover) { \n\t";
-			$gov_button_style_override .= 	"box-shadow:0 2px 0 #0b0c0c!important;\n";
-			$gov_button_style_override .= "}\n";
-			$gov_button_style_override .= ".wp-block-button__link:focus:hover,";
-			$gov_button_style_override .= ".mojblocks-button:focus:hover,";
-			$gov_button_style_override .= ".govuk-button:not(.govuk-button--secondary):focus:hover { \n\t";
-			$gov_button_style_override .= 	"box-shadow: 0 0 0 3px #FD0!important;\n";
-			$gov_button_style_override .= 	"background-color: #005a30!important;\n";
-			$gov_button_style_override .= 	"color: #fff!important;\n";
-			$gov_button_style_override .= "}\n";
-			$css .= $gov_button_style_override;
 		}
 		if (!$custom_colours_set || $logo_focus_invert) {
 			$logo_focus_invert_style  = ".govuk-header a:focus img {\n\t";

--- a/inc/colour-branding.php
+++ b/inc/colour-branding.php
@@ -86,6 +86,29 @@ function hale_generate_custom_colours() {
 				$colour_bar_style .= "}\n";
 				$css .= $colour_bar_style;
 			}
+			// Here we apply the GDS button styles which are different from non-GDS
+			// We remove rounded corners
+			// We add a box shadow for bottom
+			// We deal with their strange hover-focus combinations
+			$gov_button_style_override  = ".wp-block-button__link,";
+			$gov_button_style_override .= ".mojblocks-button,";
+			$gov_button_style_override .= ".govuk-button:not(.govuk-button--secondary) { \n\t";
+			$gov_button_style_override .= 	"border-radius:0!important;;\n\t";
+			$gov_button_style_override .= 	"box-shadow:0 2px 0 #002d18!important;\n";
+			$gov_button_style_override .= "}\n";
+			$gov_button_style_override .= ".wp-block-button__link:focus:not(:active):not(:hover),";
+			$gov_button_style_override .= ".mojblocks-button:focus:not(:active):not(:hover),";
+			$gov_button_style_override .= ".govuk-button:not(.govuk-button--secondary):focus:not(:active):not(:hover) { \n\t";
+			$gov_button_style_override .= 	"box-shadow:0 2px 0 #0b0c0c!important;\n";
+			$gov_button_style_override .= "}\n";
+			$gov_button_style_override .= ".wp-block-button__link:focus:hover,";
+			$gov_button_style_override .= ".mojblocks-button:focus:hover,";
+			$gov_button_style_override .= ".govuk-button:not(.govuk-button--secondary):focus:hover { \n\t";
+			$gov_button_style_override .= 	"box-shadow: 0 0 0 3px #FD0!important;\n";
+			$gov_button_style_override .= 	"background-color: #005a30!important;\n";
+			$gov_button_style_override .= 	"color: #fff!important;\n";
+			$gov_button_style_override .= "}\n";
+			$css .= $gov_button_style_override;
 		}
 		if (!$custom_colours_set || $logo_focus_invert) {
 			$logo_focus_invert_style  = ".govuk-header a:focus img {\n\t";

--- a/inc/colours.php
+++ b/inc/colours.php
@@ -1,7 +1,7 @@
 <?php
 
 	function hale_get_colours() {
-		//defaults
+		//defaults - GDS colours
 		$white = '#FFF';
 		$black = '#0B0C0C';
 		$yellow = '#FD0';
@@ -103,9 +103,10 @@
 			['button-border',"none",'Button border','Enter a complete CSS value for border, e.g. "solid 2px #0b0c0c", "none"','text'], // not a colour
 			['button-hover',$buttonHoverGreen,'Button hover','',''],
 			['button-hover-text',$white,'Button hover text','',''],
+			['button-hover-border','transparent','Button hover border','Leave blank for none. Requires there to be a button border set',''],
 			['button-focus',$yellow,'Button focus','',''],
 			['button-focus-text',$black,'Button focus text','',''],
-			['button-focus-outline',$yellow,'Button focus outline','',''],
+			['button-focus-outline',$yellow,'Button focus outline','This will always be thicker than any set button border',''],
 			['button-active',$buttonHoverGreen,'Button active','',''],
 
 			//mojblocks - these are usually things not found in GOV.UK sites

--- a/inc/colours.php
+++ b/inc/colours.php
@@ -151,7 +151,7 @@
 			['tag-hover-bg',$midGrey,'Tag hover background','',''],
 			['tag-hover-text',$black,'Tag hover text','',''],
 			['tag-focus-bg',$yellow,'Tag focus background','',''],
-			['tag-focus-outline',$black,'Tag focus outline','',''],
+			['tag-focus-outline',$yellow,'Tag focus outline','',''],
 			['tag-focus-text',$black,'Tag focus text','',''],
 
 			//Cookie banner

--- a/inc/colours.php
+++ b/inc/colours.php
@@ -110,9 +110,13 @@
 			['button-active',$buttonHoverGreen,'Button active','',''],
 
 			//mojblocks - these are usually things not found in GOV.UK sites
-			['mojblocks-accordion-section-title',$blue,'Accordion titles/links/controls','',''],
-			['mojblocks-accordion-section-title-hover',$darkBlue,'Accordion titles/links/controls hover','',''],
-			['mojblocks-accordion-section-title-focus',$black,'Accordion titles and links focus','',''],
+			['mojblocks-accordion-section-title',$black,'Accordion titles','',''],
+			['mojblocks-accordion-section-shew',$blue,'Accordion show links','',''],
+			['mojblocks-accordion-section-title-hover',$black,'Accordion titles hover','',''],
+			['mojblocks-accordion-section-shew-hover',$black,'Accordion show links hover','',''],
+			['mojblocks-accordion-section-item-hover-bg',$lightGrey,'Accordion item hover background','',''],
+			['mojblocks-accordion-section-title-focus',$black,'Accordion titles focus','',''],
+			['mojblocks-accordion-section-shew-focus',$black,'Accordion show links focus','',''],
 			['mojblocks-accordion-section-title-focus-bg',$yellow,'Accordion titles and links focus background','',''],
 			['mojblocks-accordion-section-title-focus-shadow',$black,'Accordion titles and links focus underline','',''],
 

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.9.2
+Version: 3.9.3
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
Colour option fixes for accordion and buttons:

## Accordion
- added missing CSS to apply the chosen colours
- added more options for more granular styling
- tested all options

## Button
- Made GDS style buttons the basis, with Hale themes overriding them
  - added a new class to use if a site has selected government styles
  - removed rounded corners (except in non-GDS style sites)
  - split up the styles in `brandings.scss` and `brandings-mojblocks.scss` into two groups:
    - those that apply to all sites (prefixed `*`, as before)
    - those that apply only to non-GDS sites (prefixed `html.hale-colours-variable`)
- removed the errant box shadow that wasn't needed and was causing issues if a button border was applied
- made the hover border customisable instead of just inheriting the link colour
- no changes to cookie banner buttons, these are a little out-of-kilter with the other buttons but it isn't that big a deal

Currently, only magistrates is using the GDS styles and I cannot see any unintended style changes.