### PR TITLE
Added new twitter logo as stopgap

### DIFF
--- a/assets/scss/icons.scss
+++ b/assets/scss/icons.scss
@@ -34,6 +34,10 @@
 
   &:before {
     content: fa-content($fa-var-twitter-square);
+    content: "𝕏"; // temporary, until Font Awesome get their act together
+    position: relative; // temporary, until Font Awesome get their act together
+    top: -2px; // temporary, until Font Awesome get their act together
+    padding: 2px; // temporary, until Font Awesome get their act together
   }
 }
 


### PR DESCRIPTION
Whilst we are waiting for Font Awesome to update their Twitter logo, or create a new X logo (whichever they choose), this PR changes the logo to 𝕏.  All labelled as temporary so they can be easily identified and removed when the new Font Awesome icon is ready.  

![image](https://github.com/ministryofjustice/wp-hale/assets/32877315/956e062d-17c9-4d96-a5f5-6b4b6f34103f)

