### PR TITLE
Added missing label for document search

### DIFF
--- a/page-document-listing.php
+++ b/page-document-listing.php
@@ -86,7 +86,7 @@ while (have_posts()) :
                 <div class="document-listing-search-section">
                     <div class="document-listing-search-form">
                         <form action="<?php echo get_permalink(); ?>" method="GET">
-
+                            <label for="doc-search-field" class="govuk-visually-hidden">Search</label>
                             <input class="govuk-input" id="doc-search-field" name="doc_search"
                                    value="<?php echo $doc_search_text; ?>" type="search"
                                    placeholder="Search">


### PR DESCRIPTION
Document search term didn't have an associated label (accessibility fail).  
I have added a visually-hidden one.