### PR TITLE
Applied govuk styling (font size) to all wp tables

### DIFF
--- a/assets/scss/core-wp-blocks-overrides.scss
+++ b/assets/scss/core-wp-blocks-overrides.scss
@@ -8,17 +8,23 @@ Overrides core block styling so GDS styling can take effect
 //Only adjust default pattern (:not(.is-style-stripes))
 //Targetting .is-style-regular isn't robust as the class doesn't appear by default
 //revert settings which override GDS
-.wp-block-table:not(.is-style-stripes) {
-	td, th {
-		border: unset;
+.wp-block-table {
+	table {
+		@extend .govuk-table;
 	}
-	thead {
-		border-bottom: unset;
-	}
-	tfoot {
-		border-top: unset;
-	}
-	figcaption {
-		text-align: unset;
+
+	&:not(.is-style-stripes) {
+		td, th {
+			border: unset;
+		}
+		thead {
+			border-bottom: unset;
+		}
+		tfoot {
+			border-top: unset;
+		}
+		figcaption {
+			text-align: unset;
+		}
 	}
 }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.11.2
+Version: 3.11.3
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
Extends the `govuk-table` class to all wordpress table blocks.  
This makes the font size 19px (16px on mobile) common with the rest of the text.