### PR TITLE
Added specific font declaration for headings

### DIFF
--- a/assets/scss/gds-design-system-settings.scss
+++ b/assets/scss/gds-design-system-settings.scss
@@ -25,6 +25,9 @@ $govuk-font-family: 'PT Sans', sans-serif;
         padding:0;
       }
     }
+    h1,h2,h3,h4,h5,h6 {
+      font-family: $govuk-font-family;
+    }
   }
   .hale-footer__copyright a {
     @extend .govuk-footer__link;

--- a/assets/scss/gds-design-system-settings.scss
+++ b/assets/scss/gds-design-system-settings.scss
@@ -15,6 +15,9 @@ $govuk-font-family: 'PT Sans', sans-serif;
   .hale-search-header + div {
 		margin-top: 30px;
 	}
+  h1,h2,h3,h4,h5,h6 {
+    font-family: $govuk-font-family;
+  }
   #primary {
     font-family: $govuk-font-family;
 
@@ -24,9 +27,6 @@ $govuk-font-family: 'PT Sans', sans-serif;
         width: 150%;
         padding:0;
       }
-    }
-    h1,h2,h3,h4,h5,h6 {
-      font-family: $govuk-font-family;
     }
   }
   .hale-footer__copyright a {

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.11.3
+Version: 3.11.4
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
Added specific font declaration for headings
- News section headings was still using the GDS transport font.  This ensures that the PT Sans font is used.