### PR TITLE
specified that styles are content-area only

### DIFF
--- a/assets/scss/style-gutenburg.scss
+++ b/assets/scss/style-gutenburg.scss
@@ -28,7 +28,7 @@ $gutenberg-styles: true;
   }
 }
 
-*{
+.edit-post-visual-editor__content-area {
   .govuk-link,
   a,
   a:not([class]) {


### PR DESCRIPTION
Custom colours were being used for backend controls - this kills that off.