### PR TITLE
Changed the social focus underline to match footer links

### DIFF
--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -710,8 +710,8 @@ html.hale-colours-variable {
 			box-shadow:
 				-4px 0 var(--footer-link-focus-background),
 				4px 0 var(--footer-link-focus-background),
-				-4px 4px var(--link-focus),
-				4px 4px var(--link-focus);
+				-4px 4px var(--footer-link-focus-shadow),
+				4px 4px var(--footer-link-focus-shadow);
 		}
 	}
 	.job-list-item {


### PR DESCRIPTION
Previously, the footer social widgets were using the main link colour for their focus underline.  This is an obvious mistake.  This PR changes it to be in line with the rest of the footer links.  The focus background was already in line with the footer links so it makes sense that these are kept in synch.  