### PR TITLE
Added correct URI for footer logo

### DIFF
--- a/assets/scss/footer.scss
+++ b/assets/scss/footer.scss
@@ -43,7 +43,3 @@
 .hale-footer__copyright {
   margin-top: 1rem;
 }
-
-.govuk-footer__copyright-logo {
-  background-image: url("../images/govuk-crest-2x.png");
-}

--- a/footer.php
+++ b/footer.php
@@ -59,7 +59,13 @@ flush();
         if ('yes' == $crown_copyright) {
       ?>
         <div class="govuk-footer__meta-item">
-          <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+          <a
+            class="govuk-footer__link govuk-footer__copyright-logo"
+            href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+            style="background-image:url(<?php echo get_template_directory_uri(); ?>/assets/images/govuk-crest-2x.png);"
+          >
+            © Crown copyright
+          </a>
         </div>
       <?php
         }


### PR DESCRIPTION
Pointed the footer copyright logo to the correct place using inline styles (as PHP used to get directory).  
Removed old style which wasn't working.

Note that this at current only affects Hale Help, but all sites could use this if they wanted as it is one of our footer options.