### PR TITLE
Corrected prison name in list & added class

### DIFF
--- a/inc/job-prison-locations.php
+++ b/inc/job-prison-locations.php
@@ -632,9 +632,8 @@
 			   "name_variations":[
 				  "HM Prison New Hall",
 				  "HMP New Hall",
-				  "HMP\/YOI New Hall &",
-				  "HMP & YOI New Hall &",
-				  "HMYOI New Hall &"
+				  "HMP & YOI New Hall",
+				  "HMYOI New Hall"
 			   ]
 			},
 			{

--- a/template-parts/content-job-list-item.php
+++ b/template-parts/content-job-list-item.php
@@ -120,8 +120,8 @@
     }
 ?>
 
-
-<div class="job-list-item" id="job-<?php echo $id; ?>" <?php echo get_prison_names(get_the_title(),$addressField);?>>
+<?php // find-a-job__view-list-element class added for Google Tag Manager consistency with old site ?>
+<div class="job-list-item find-a-job__view-list-element" id="job-<?php echo $id; ?>" <?php echo get_prison_names(get_the_title(),$addressField);?>>
     <h2 class="job-list-item--title govuk-heading-m">
         <a class="govuk-link" href="<?php printf($url);?>">
             <?php echo get_the_title(); ?>


### PR DESCRIPTION
Changed the alias for HMP New Hall - existing alias included ampersand which was causing identification to fail.

Added new class for consistency with previous GTM.