### PR TITLE
404 search box

### DIFF
--- a/404.php
+++ b/404.php
@@ -23,7 +23,7 @@ get_header();
         alternatively <a class="govuk-link" href="<?php echo esc_attr( get_home_url() ); ?>">return to the home page</a>.
       </p>
       <?php
-        get_search_form();
+        if (get_theme_mod( 'show_search', 'yes' ) === "yes") get_search_form();
       ?>
       <div class="govuk-clearfix"></div>
     </section>

--- a/404.php
+++ b/404.php
@@ -11,20 +11,46 @@ get_header();
 ?>
 	<div id="primary" class="govuk-grid-column-two-thirds">
     <section class="hale-error-404">
-      <h1 class="govuk-heading-l">Page not found</h1>
-      <p class="govuk-body">
-        If you typed the web address, check it is correct.
-      </p>
-      <p class="govuk-body">
-        If you pasted the web address, check you copied the entire address.
-      </p>
-      <p class="govuk-body">
-        Use the search facility below, select an item from the contents or 
-        alternatively <a class="govuk-link" href="<?php echo esc_attr( get_home_url() ); ?>">return to the home page</a>.
-      </p>
+      <h1 class="govuk-heading-l">
       <?php
-        if (get_theme_mod( 'show_search', 'yes' ) === "yes") get_search_form();
+        if (get_locale() == 'cy') {
+          echo esc_html__("Tudalen heb ei chanfod","hale");
+        } else {
+          echo esc_html__("Page not found","hale");
+        }
       ?>
+      </h1>
+      <p class="govuk-body">
+        <?php
+          if (get_locale() == 'cy') {
+            echo esc_html__("Gwnewch yn siŵr eich bod wedi rhoi'r cyfeiriad gwe cywir.","hale");
+          } else {
+            echo esc_html__("If you typed the web address, check it is correct.","hale");
+          }
+        ?>
+      </p>
+      <p class="govuk-body">
+      <?php
+        echo esc_html__("If you pasted the web address, check you copied the entire address.","hale");
+      ?>
+      </p>
+<?php
+      if (get_theme_mod( 'show_search', 'yes' ) === "yes") {
+?>
+        <p class="govuk-body">
+          Use the search facility below, select an item from the contents or alternatively
+          <a class="govuk-link" href="<?php echo esc_attr( get_home_url() ); ?>">return to the home page</a>.
+        </p>
+<?php
+        get_search_form();
+      } else {
+?>
+        <p class="govuk-body">
+          Please <a href="<?php echo get_site_url(); ?>" class="govuk-link">return to the home page</a> or try again.
+        </p>
+<?php
+      }
+?>
       <div class="govuk-clearfix"></div>
     </section>
 		<div class="govuk-grid-column-full ">


### PR DESCRIPTION
- Only display the search box if show_search is yes.
- Otherwise display a sentence telling the user to try again or go to the home page (with link).
- Added some Welsh translations for the page - but only those which I can be sure of the translations, so not the whole page.  (I'm assuming some is better than none here.)