### PR TITLE
Footer white bar fix

### DIFF
--- a/assets/scss/brandings.scss
+++ b/assets/scss/brandings.scss
@@ -681,6 +681,7 @@ html.hale-colours-variable {
 		border-top-width: 4px;
 		border-top-color: var(--footer-border);
 		background: var(--footer-background);
+		box-shadow: 0 20px 0 0 var(--footer-background);
 
 		a:not([class]),
 		a[class=""],

--- a/assets/scss/undesirables-handling.scss
+++ b/assets/scss/undesirables-handling.scss
@@ -1,0 +1,10 @@
+/**
+ * This file was added to hide the undesirable 1×1px image that is added
+ * by Facebook marketing cookies.  
+ *
+ * It can be used to handle other undesirable stuff that might turn up.  
+**/
+
+body>img {
+	display: none;
+}

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: Hale
 Text Domain: hale
-Version: 3.11.13
+Version: 3.11.16
 Description: Theme for Ministry of Justice websites.
 Author: Ministry of Justice - Adam Brown, Beverley Newing, Damien Wilson, Malcolm Butler & Robert Lowe
 */


### PR DESCRIPTION
This is a quick fix to the footer bug where a white bar is shewn at the bottom of the screen.  

Bug is caused by a seemingly invisible image added after the footer - bottom of body.

Fixed in 2 ways:
- `box-shadow` to extend beyond the footer to cover up any bar
- `display:none` to hide the 1×1px image which is added by Facebook cookies that causes this issue

The first of these will prevent these sorts of issues, assuming the code adds them at the bottom of the page after the footer.  
The second will work if it is an image added just beneath the body at any point.  
Both will work in this situation.